### PR TITLE
Added: Example how to state measurement errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,5 @@ dist/
 # Pytest cache
 .pytest_cache/
 
-# Example data and analysis examples
-example_data/
-examples/
-
 # Generated documentation
 docs/echem_data_tool/

--- a/design-docs/file_format_specs.md
+++ b/design-docs/file_format_specs.md
@@ -184,7 +184,7 @@ graph LR
 - **Cell groups**: Named as `cell_XXX` where XXX is a zero-padded number (001, 002, ...)
 - **Technique groups**: Named as `technique_XXX_YYYY` where:
   - XXX is the sequence number (001, 002, ...)
-  - YYYY is the technique type (OCV, cycling, CV, EIS, etc.)
+  - YYYY is the technique type (OCV, CYCLING, CV, EIS, etc.)
 - **Auxiliary data groups**: Named as `auxiliary_XXX_YYYY` where:
   - XXX is the sequence number (001, 002, ...)
   - YYYY is the data type (temperature, UVVis, pressure, etc.)
@@ -273,6 +273,9 @@ Global information about the entire study stored as NetCDF attributes. Contains 
         "country": "USA", 
         "grant_number": "INT-2024-001",
       }
+    ],
+    "cells": [
+      { /* CELL-LEVEL METADATA HERE */ }
     ]
   }
 }
@@ -299,6 +302,12 @@ Physical and configuration details for each electrochemical cell. Contains essen
       "environment": "argon glovebox",
     },
     "nominal_capacity_ah": 0.000127, // theoretical capacity (academic) or nominal (commercial)
+    "techniques": [
+      { /* TECHNIQUE-LEVEL METADATA HERE (see definitions below) */ }
+    ],
+    "auxiliaries": [
+      { /* AUXILIARY-LEVEL METADATA HERE (see definitions below) */ }
+    ]
   },
   "secondary": { // in the ideal case this should cover all different cell types
     "components": [
@@ -620,7 +629,7 @@ Parameters and conditions for each electrochemical measurement. Contains essenti
     "id": 1, // this number should be unique and will also be used to get the sequence of applied techniques
     "group": {
       "name": "nicholson_analysis", // optional: group name
-      "group_id": 1,  // unique ID for a single group, but multiple techniques/auxilaries can belong to the same group
+      "id": 1,  // unique ID for a single group, but multiple techniques/auxilaries can belong to the same group
     },
     "auxiliary": false, // always false for techniques, only true for auxilary data
     "type": "cyclic_voltammetry",  // NOTE: different scan rates would be set up as different techniques bundled in a group
@@ -707,7 +716,7 @@ Information for parallel measurements and monitoring. Contains essential sensor 
     "id": 1, // this number should be unique and will also be used to get the sequence of applied auxilaries
     "group": {
       "name": "nicholson_analysis", // optional: group name
-      "group_id": 1,  // unique ID for a single group, but multiple techniques/auxilaries can belong to the same group
+      "id": 1,  // unique ID for a single group, but multiple techniques/auxilaries can belong to the same group
     },
     "auxiliary": true,
     "type": "temperature",

--- a/design-docs/file_format_specs.md
+++ b/design-docs/file_format_specs.md
@@ -319,7 +319,7 @@ Physical and configuration details for each electrochemical cell. Contains essen
             "name": "PFPMAm-co-TEGDMA (1%)",
             "type": "active_material",
             "amount": { // define amount/number/fraction/...
-              "value": 60,
+              "value": [60, 5], // show that values can be numbers, but also a tuple with two elements to be understood as VALUE ± ERROR to state measurement uncertainties
               "unit": "wt.-%"
             }
           },

--- a/examples/001_create_file_with_metadata/polymer_zinc_battery_example.py
+++ b/examples/001_create_file_with_metadata/polymer_zinc_battery_example.py
@@ -1,0 +1,1104 @@
+#!/usr/bin/env python3
+
+"""
+Comprehensive example: Polymer/Zinc thin-film battery study
+Demonstrates complete metadata handling with the new metadata module.
+
+This example shows a realistic electrochemical study with:
+
+- Study metadata with multiple contributors and funding sources
+- Detailed cell construction with materials and procedures
+- Multiple measurement techniques (CV and charge/discharge)
+- Auxiliary temperature monitoring
+- Complete metadata serialization and structure demonstration
+
+NOTE: The example content is fictional and currently not fully consistent.
+      It is for demonstration purposes only and will be improved in the future.
+
+"""
+
+import sys
+import json
+from datetime import datetime, timedelta
+sys.path.append('src')
+
+from echem_data_tool.file import (
+    FileObject
+)
+
+def create_polymer_zinc_study():
+    """Create comprehensive metadata for a polymer/zinc thin-film battery study."""
+    
+    print("🔋 Creating Polymer/Zinc Thin-Film Battery Study")
+    print("=" * 60)
+
+    # =================================================================
+    # CREATE FILE AND STUDY LAYOUT
+    # =================================================================
+    
+    # create a new file object for this study
+    my_first_study_file = FileObject()
+
+    # ADD CELL 1
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    cell = my_first_study_file.add_cell("cell_001")
+    cv_technique = cell.add_technique("technique_001_CV")
+    cv_technique_2 = cell.add_technique("technique_002_CV")
+    gcd_technique = cell.add_technique("technique_003_GCD")
+    temperature_aux = cell.add_auxiliary("auxiliary_001_temperature")
+
+    # Group the CV techniques
+    cv_group = cell.add_group(id=1, name="Cyclic Voltammetry")
+    cv_group.add_technique([cv_technique, cv_technique_2])
+    
+    # ADD CELL 2
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    cell_2 = my_first_study_file.add_cell("cell_002")
+    eis_technique = cell_2.add_technique("technique_001_EIS")
+    cv_slow_technique = cell_2.add_technique("technique_002_CV")
+    pressure_aux = cell_2.add_auxiliary("auxiliary_001_pressure")
+
+    # NOTE: The layout can also be created on the fly, but the definition 
+    #       at the top like done here provides immediate clarity about the
+    #       structure.
+
+    # =================================================================
+    # 1. STUDY METADATA
+    # =================================================================
+    
+    # Set study metadata directly on the file object
+    my_first_study_file.metadata.id = "PZB_2025_001_ThinFilm_Characterization"
+    my_first_study_file.metadata.description = (
+        "Electrochemical characterization of polymer/zinc thin-film batteries "
+        "fabricated via solution processing in inert atmosphere. Investigation "
+        "of cycling stability and rate capability using cyclic voltammetry "
+        "and galvanostatic charge-discharge protocols."
+    )
+    my_first_study_file.metadata.format_version = "1.0.0"
+    
+    # Add research team
+    my_first_study_file.metadata.add_contributor(
+        name="Dr. Elena Müller",
+        email="elena.mueller@uni-jena.de", 
+        affiliation="Friedrich-Schiller-Universität Jena, Institute of Physical Chemistry",
+        additional_info=[
+            ("orcid", "0000-0002-1234-5678"),
+            ("role", "Principal Investigator")
+        ]
+    )
+    
+    my_first_study_file.metadata.add_contributor(
+        name="Marcus Weber",
+        email="marcus.weber@uni-jena.de",
+        affiliation="Friedrich-Schiller-Universität Jena, Graduate School",
+        additional_info=[
+            ("orcid", "0000-0003-9876-5432"),
+            ("role", "PhD Student - Cell Fabrication & Testing")
+        ]
+    )
+    
+    my_first_study_file.metadata.add_contributor(
+        name="Dr. Sarah Chen",
+        email="sarah.chen@uni-jena.de",
+        affiliation="Friedrich-Schiller-Universität Jena, CEEC Jena",
+        additional_info=[
+            ("orcid", "0000-0001-2468-1357"),
+            ("role", "Postdoctoral Researcher - Materials Development")
+        ]
+    )
+    
+    # Add funding sources
+    my_first_study_file.metadata.add_funding(
+        agency="Deutsche Forschungsgemeinschaft (DFG)",
+        country="Germany", 
+        grant_number="MU 1234/5-2"
+    )
+    
+    my_first_study_file.metadata.add_funding(
+        agency="Bundesministerium für Bildung und Forschung (BMBF)",
+        country="Germany",
+        grant_number="03EK3045A - FestBatt"
+    )
+    
+    # Output summary
+    print(f"✅ Study '{my_first_study_file.metadata.id}' created")
+    print(f"   - {len(my_first_study_file.metadata.contributors)} contributors")
+    print(f"   - {len(my_first_study_file.metadata.funding)} funding sources")    
+    
+    # =================================================================
+    # 2. CELL METADATA - Thin-film battery construction
+    # =================================================================
+    base_timestamp = datetime.now() - timedelta(days=7)
+    
+    # add cell metadata 
+    cell.metadata.id = "PZB-TF-001"
+    cell.metadata.type = "Pouch Cell"
+    cell.metadata.cathode = "PTAm"
+    cell.metadata.anode = "Zn"
+    cell.metadata.electrolyte = "aqueous"
+    cell.metadata.objective = "Electrochemical characterization of polymer/zinc thin-film battery"
+    cell.metadata.nominal_capacity_ah = 0.00015
+    cell.metadata.assembly_timestamp = base_timestamp
+    cell.metadata.assembly_manufacturer = "Friedrich-Schiller-Universität Jena"
+    cell.metadata.assembly_environment = "Argon-filled glove box (H2O < 0.5 ppm, O2 < 0.5 ppm)"
+
+    # ANODE: Zinc thin-film
+    # NOTE Alternative 1 to add a component with all information at once
+    cell.metadata.add_component(
+        name="anode",
+        materials=[
+            ("Zinc", "active_material", 100.0, "wt%")
+        ],
+        procedures=[
+            ("substrate_cleaning", "acetone/IPA/DI_water_sequence", None),
+            ("deposition_method", "RF_sputtering", None),
+            ("deposition_temperature", 150.0, "°C"),
+            ("annealing_temperature", 300.0, "°C")
+        ],
+        properties=[
+            ("thickness", 2.5, "µm"),
+            ("sheet_resistance", 8.2, "Ω/sq"),
+            ("surface_roughness_Ra", 45, "nm")
+        ]
+    )
+    
+    # CATHODE: PTAm (Poly(TEMPO-amide)) composite
+    # NOTE: Alternative 2 to add a component with information step-by-step via methods
+    cathode = cell.metadata.add_component(name="cathode")
+
+    # Cathode materials
+    cathode.add_material("Poly(TEMPO-amide)", "redox_active_polymer", 60.0, "wt%")
+    cathode.add_material("SuperP", "conductive_additive", 35.0, "wt%")
+    cathode.add_material("Cellulose", "binder", 5.0, "wt%")
+    
+    # Cathode fabrication procedures
+    cathode.add_procedure("preparation", """
+        1. Weigh the required amounts of dry PTAm, SuperP, and Cellulose.
+        2. Disperse the materials in water using a Dispermat.
+        3. Coat the slurry onto the substrate via doctor blading.
+    """, None)
+    cathode.add_procedure("mixing_method", "Dispermat", None)
+    cathode.add_procedure("mixing_speed", 8000, "rpm")
+    cathode.add_procedure("mixing_time", 30, "min")
+    cathode.add_procedure("solvent", "isopropanol", None)
+    cathode.add_procedure("coating_method", "doctor_blading", None)
+    cathode.add_procedure("coating_speed", "1000", "µm/s")
+    cathode.add_procedure("coating_thickness", 200, "µm")
+    cathode.add_procedure("drying_temperature", 60.0, "°C")
+    cathode.add_procedure("annealing_temperature", 100.0, "°C")
+    
+    # Cathode properties  
+    cathode.add_property("mass_loading", 4.1, "mg/cm²")
+    cathode.add_property("theoretical_capacity", 111, "mAh/g")
+    cathode.add_property("dry_thickness", 20, "µm")
+    
+    # ELECTROLYTE: Solid polymer electrolyte
+    cell.metadata.add_component(
+        name="electrolyte", 
+        materials=[
+            ("Poly(ethylene oxide)", "polymer_host", 60.0, "wt%"),
+            ("LiTFSI", "lithium_salt", 25.0, "wt%"),
+            ("Zn(CF3SO3)2", "zinc_salt", 15.0, "wt%")
+        ],
+        procedures=[
+            ("dissolution_method", "stirring", None),
+            ("dissolution_solvent", "acetonitrile", None),
+            ("dissolution_temperature", 60.0, "°C"),
+            ("dissolution_time", 12, "h"),
+            ("casting_method", "doctor_blade", None),
+            ("evaporation_control", "controlled_atmosphere", None)
+        ],
+        properties=[
+            ("ionic_conductivity", 2.1e-4, "S/cm"),
+            ("thickness", 25, "µm")
+        ]
+    )
+
+    # ANODE CURRENT COLLECTOR: Stainless steel foil
+    cell.metadata.add_component(
+        name="anode_current_collector",
+        materials=[
+            ("Stainless steel foil", "current_collector", 100.0, "wt%")
+        ],
+        properties=[
+            ("thickness", 20, "µm")
+        ]
+    )
+
+    # HOUSING/PACKAGING: Pouch cell packaging
+    cell.metadata.add_component(
+        name="housing",
+        materials=[
+            ("Aluminum-laminated film", "pouch_material", None, None)
+        ],
+        procedures=[
+            ("sealing_method", "heat_sealing", None),
+            ("sealing_temperature", 180.0, "°C"),
+            ("pressing_force", 2.0, "MPa")
+        ],
+        properties=[
+            ("barrier_thickness", 115, "µm"),
+            ("moisture_barrier", "<0.01", "g/m²/day")
+        ]
+    )
+    
+    # Assembly parameters as structured data
+    cell.metadata.add_note(
+        name="glove_box_model",
+        value="MBraun LABmaster dp"
+    )
+    
+    cell.metadata.add_note(
+        name="pressing_force",
+        value="2 MPa"
+    )
+    
+    cell.metadata.add_note(
+        name="conditioning_protocol",
+        value="24h at 60°C before electrochemical testing"
+    )
+    
+    print(f"\n✅ Cell '{cell.metadata.id}' created")
+    print(f"   - {len(cell.metadata.components)} components (including electrolyte)")
+    print(f"   - Assembly: {cell.metadata.assembly.timestamp.strftime('%Y-%m-%d %H:%M') if cell.metadata.assembly.timestamp else 'N/A'}")
+    
+    # =================================================================
+    # 3. TECHNIQUE 1: Cyclic Voltammetry (10 mV/s)
+    # =================================================================
+    cv_start = base_timestamp + timedelta(seconds=280)
+    cv_end = cv_start + timedelta(seconds=28)
+    
+    # Set technique metadata properties
+    cv_technique.metadata.id = 1
+    cv_technique.metadata.type = "Cyclic Voltammetry"
+    cv_technique.metadata.start = cv_start
+    cv_technique.metadata.end = cv_end
+    
+    # CV equipment
+    cv_technique.metadata.add_device(
+        name="VMP3_Potentiostat",
+        type="potentiostat",
+        manufacturer="BioLogic Science Instruments",
+        model="VMP3",
+        software_name="EC-Lab",
+        software_version="11.50"
+    )
+    
+    # CV parameters
+    cv_technique.metadata.add_setting("initial_potential", 0.8, "V")
+    cv_technique.metadata.add_setting("initial_potential_hold", 30, "s")
+    cv_technique.metadata.add_setting("vertex_potential_low", 0.8, "V") 
+    cv_technique.metadata.add_setting("vertex_potential_high", 2.2, "V")
+    cv_technique.metadata.add_setting("scan_rate", 10, "mV/s")
+    cv_technique.metadata.add_setting("cycle_count", 1, None)
+    cv_technique.metadata.add_setting("current_range", 10, "mA")
+    cv_technique.metadata.add_setting("potential_range", [-2.5, 2.5], "V")
+    cv_technique.metadata.add_setting("bandwidth", 7, None)
+    
+    cv_technique.metadata.add_note(
+        name="measurement_purpose", 
+        value="Electrochemical stability window determination and redox peak identification"
+    )
+    
+    cv_technique.metadata.add_note(
+        name="potentiostat_channel",
+        value=1
+    )
+    
+    print(f"\n✅ CV Technique created")
+    print(f"   - Duration: {cv_start.strftime('%H:%M')} - {cv_end.strftime('%H:%M')}")
+    print(f"   - {len(cv_technique.metadata.devices)} device, {len(cv_technique.metadata.settings)} parameters")
+    
+    # =================================================================
+    # 4. TECHNIQUE 2: Cyclic Voltammetry (100 mV/s)
+    # =================================================================
+    cv2_start = cv_end
+    cv2_end = cv2_start + timedelta(seconds=28)
+    
+    # Get existing technique (created in minimal example)
+    cv_technique_2 = cell.get_technique("technique_002_CV")
+    
+    # Set technique metadata properties
+    cv_technique_2.metadata.id = 2
+    cv_technique_2.metadata.type = "Cyclic Voltammetry"
+    cv_technique_2.metadata.start = cv2_start
+    cv_technique_2.metadata.end = cv2_end
+    
+    # CV equipment (same potentiostat, different channel)
+    cv_technique_2.metadata.add_device(
+        name="VMP3_Potentiostat",
+        type="potentiostat",
+        manufacturer="BioLogic Science Instruments",
+        model="VMP3",
+        software_name="EC-Lab",
+        software_version="11.50"
+    )
+    
+    # CV parameters
+    cv_technique_2.metadata.add_setting("initial_potential", 0.8, "V")
+    cv_technique_2.metadata.add_setting("initial_potential_hold", 30, "s")
+    cv_technique_2.metadata.add_setting("vertex_potential_low", 0.8, "V") 
+    cv_technique_2.metadata.add_setting("vertex_potential_high", 2.2, "V")
+    cv_technique_2.metadata.add_setting("scan_rate", 100, "mV/s")
+    cv_technique_2.metadata.add_setting("cycle_count", 1, None)
+    cv_technique_2.metadata.add_setting("current_range", 10, "mA")
+    cv_technique_2.metadata.add_setting("potential_range", [-2.5, 2.5], "V")
+    cv_technique_2.metadata.add_setting("bandwidth", 7, None)
+    
+    cv_technique_2.metadata.add_note(
+        name="measurement_purpose", 
+        value="Higher scan rate CV for kinetic analysis"
+    )
+    
+    cv_technique_2.metadata.add_note(
+        name="potentiostat_channel",
+        value=1
+    )
+    
+    print(f"\n✅ CV Technique 2 created")
+    print(f"   - Duration: {cv2_start.strftime('%H:%M')} - {cv2_end.strftime('%H:%M')}")
+    print(f"   - {len(cv_technique_2.metadata.devices)} device, {len(cv_technique_2.metadata.settings)} parameters")
+    
+    # =================================================================
+    # 5. TECHNIQUE 3: Galvanostatic Charge/Discharge
+    # =================================================================
+    gcd_start = cv2_end + timedelta(hours=0.5)  # Rest period after second CV
+    gcd_end = gcd_start + timedelta(hours=8)  # 8-hour cycling test
+    
+    # Get existing technique (created in minimal example)
+    gcd_technique = cell.get_technique("technique_003_GCD")
+    
+    # Set technique metadata properties
+    gcd_technique.metadata.id = 3
+    gcd_technique.metadata.type = "Galvanostatic Charge-Discharge Cycling"
+    gcd_technique.metadata.start = gcd_start
+    gcd_technique.metadata.end = gcd_end
+    
+    # Same potentiostat, different channel
+    gcd_technique.metadata.add_device(
+        name="VMP3_Potentiostat", 
+        type="potentiostat",
+        manufacturer="BioLogic Science Instruments",
+        model="VMP3",
+        software_name="EC-Lab", 
+        software_version="11.50"
+    )
+    
+    # GCD parameters
+    gcd_technique.metadata.add_setting("charge_current", 0.1, "mA")
+    gcd_technique.metadata.add_setting("discharge_current", 0.1, "mA") 
+    gcd_technique.metadata.add_setting("voltage_limit_high", 2.1, "V")
+    gcd_technique.metadata.add_setting("voltage_limit_low", 0.9, "V")
+    gcd_technique.metadata.add_setting("cycle_count", 20, None)
+    gcd_technique.metadata.add_setting("current_range", 10, "mA")
+    gcd_technique.metadata.add_setting("rest_time", 10, "min")
+    gcd_technique.metadata.add_setting("c_rates", [0.2, 0.5, 1.0, 2.0], "C")
+    gcd_technique.metadata.add_setting("cycles_per_rate", 5, None)
+    
+    gcd_technique.metadata.add_setting("temperature", 25, "°C")
+    
+    gcd_technique.metadata.add_note(
+        name="measurement_purpose",
+        value="Capacity retention and rate capability assessment"
+    )
+    
+    gcd_technique.metadata.add_note(
+        name="potentiostat_channel",
+        value=2
+    )
+    
+    print(f"\n✅ GCD Technique created") 
+    print(f"   - Duration: {gcd_start.strftime('%H:%M')} - {gcd_end.strftime('%H:%M')}")
+    print(f"   - {len(gcd_technique.metadata.devices)} device, {len(gcd_technique.metadata.settings)} parameters")
+    
+    # =================================================================
+    # 6. AUXILIARY DATA: Temperature Monitoring
+    # =================================================================
+    # Temperature monitoring runs during all techniques
+    temp_start = cv_start - timedelta(minutes=30)  # Start before first technique
+    temp_end = gcd_end + timedelta(minutes=30)     # End after last technique
+    
+    # Get existing auxiliary (created in minimal example)
+    temperature_aux = cell.get_auxiliary("auxiliary_001_temperature")
+    
+    # Set auxiliary metadata properties
+    temperature_aux.metadata.id = 1
+    temperature_aux.metadata.type = "Temperature Monitoring"
+    temperature_aux.metadata.start = temp_start
+    temperature_aux.metadata.end = temp_end
+    temperature_aux.metadata.parent_techniques = [1, 2, 3]  # Monitor during all three techniques
+    # No group needed - single temperature auxiliary
+    
+    # Temperature measurement equipment
+    temperature_aux.metadata.add_device(
+        name="TC_Cell_Surface",
+        type="thermocouple", 
+        manufacturer="Omega Engineering",
+        model="5TC-TT-K-40-36",
+        software_name="OMEGAware",
+        software_version="2.1"
+    )
+    
+    temperature_aux.metadata.add_device(
+        name="DAQ_NI_6211",
+        type="data_acquisition",
+        manufacturer="National Instruments", 
+        model="USB-6211",
+        software_name="LabVIEW",
+        software_version="2023"
+    )
+    
+    # Temperature monitoring settings
+    temperature_aux.metadata.add_setting("sampling_rate", 1.0, "Hz")
+    temperature_aux.metadata.add_setting("temperature_range_min", 15, "°C")
+    temperature_aux.metadata.add_setting("temperature_range_max", 45, "°C")
+    temperature_aux.metadata.add_setting("thermocouple_type", "K", None)
+    temperature_aux.metadata.add_setting("cold_junction_compensation", True, None)
+    temperature_aux.metadata.add_setting("averaging_samples", 10, None)
+    
+    temperature_aux.metadata.add_setting("sensor_location", "cell_surface", None)
+    temperature_aux.metadata.add_setting("adhesive_type", "thermally_conductive", None)
+    temperature_aux.metadata.add_setting("reference_distance", 10, "cm")
+    
+    temperature_aux.metadata.add_note(
+        name="measurement_purpose",
+        value="Thermal monitoring for temperature-dependent performance correlation"
+    )
+    
+    print(f"\n✅ Temperature monitoring created")
+    print(f"   - Duration: {temp_start.strftime('%H:%M')} - {temp_end.strftime('%H:%M')}")
+    print(f"   - Covers techniques: {temperature_aux.metadata.parent_techniques}")
+    print(f"   - {len(temperature_aux.metadata.devices)} devices")
+    
+    print(f"\n✅ Cell was added to file object")
+    print(f"   - File object now contains {len(my_first_study_file.cells)} cell(s)")
+    
+    # =================================================================
+    # 7. SECOND CELL - Different construction and testing
+    # =================================================================
+    
+    print("\n" + "="*60)
+    print("🔋 CREATING SECOND CELL - Different Configuration")
+    print("="*60)
+    
+    # Second cell metadata - different construction approach
+    cell_2.metadata.id = "PZB-TF-002"
+    cell_2.metadata.type = "Coin Cell"
+    cell_2.metadata.cathode = "PTMA"  # Different polymer
+    cell_2.metadata.anode = "Zn"
+    cell_2.metadata.electrolyte = "gel_polymer"
+    cell_2.metadata.objective = "Performance comparison with different polymer cathode and gel electrolyte"
+    cell_2.metadata.nominal_capacity_ah = 0.00012  # Slightly smaller capacity
+    cell_2.metadata.assembly_timestamp = base_timestamp + timedelta(days=1)  # Assembled one day later
+    cell_2.metadata.assembly_manufacturer = "Friedrich-Schiller-Universität Jena"
+    cell_2.metadata.assembly_environment = "Dry room (relative humidity < 2%)"
+    
+    # ANODE: Electroplated zinc (different method)
+    cell_2.metadata.add_component(
+        name="anode",
+        materials=[
+            ("Zinc", "active_material", 100.0, "wt%")
+        ],
+        procedures=[
+            ("substrate_cleaning", "plasma_cleaning", None),
+            ("deposition_method", "electroplating", None),
+            ("electrolyte_solution", "ZnSO4_0.1M", None),
+            ("current_density", 5.0, "mA/cm²"),
+            ("deposition_time", 45, "min"),
+            ("post_treatment", "rinsing_DI_water", None)
+        ],
+        properties=[
+            ("thickness", 3.2, "µm"),
+            ("surface_roughness_Ra", 28, "nm"),
+            ("grain_size", 150, "nm")
+        ]
+    )
+    
+    # CATHODE: PTMA (Poly(2,2,6,6-tetramethyl-1-piperidinyloxy-4-yl methacrylate))
+    cathode_2 = cell_2.metadata.add_component(name="cathode")
+    
+    # Different polymer cathode materials
+    cathode_2.add_material("Poly(TEMPO methacrylate)", "redox_active_polymer", 70.0, "wt%")
+    cathode_2.add_material("Ketjen Black", "conductive_additive", 25.0, "wt%")
+    cathode_2.add_material("PVDF", "binder", 5.0, "wt%")
+    
+    # Different fabrication process
+    cathode_2.add_procedure("preparation", """
+        1. Dissolve PTMA and PVDF in NMP solvent.
+        2. Add Ketjen Black and mix using planetary mixer.
+        3. Cast onto aluminum foil using automatic coater.
+    """, None)
+    cathode_2.add_procedure("mixing_method", "planetary_mixer", None)
+    cathode_2.add_procedure("mixing_speed", 2000, "rpm")
+    cathode_2.add_procedure("mixing_time", 45, "min")
+    cathode_2.add_procedure("solvent", "N-methyl-2-pyrrolidone", None)
+    cathode_2.add_procedure("coating_method", "automatic_coater", None)
+    cathode_2.add_procedure("coating_speed", 500, "µm/s")
+    cathode_2.add_procedure("wet_thickness", 150, "µm")
+    cathode_2.add_procedure("drying_condition", "vacuum_80C_12h", None)
+    
+    # Different cathode properties
+    cathode_2.add_property("mass_loading", 3.8, "mg/cm²")
+    cathode_2.add_property("theoretical_capacity", 111, "mAh/g")
+    cathode_2.add_property("dry_thickness", 18, "µm")
+    cathode_2.add_property("porosity", 45, "%")
+    
+    # ELECTROLYTE: Gel polymer electrolyte (different from first cell)
+    cell_2.metadata.add_component(
+        name="electrolyte",
+        materials=[
+            ("PMMA", "polymer_matrix", 45.0, "wt%"),
+            ("Propylene carbonate", "plasticizer", 30.0, "wt%"),
+            ("Zn(ClO4)2", "zinc_salt", 20.0, "wt%"),
+            ("Ethylene carbonate", "co_solvent", 5.0, "wt%")
+        ],
+        procedures=[
+            ("preparation_method", "solution_casting", None),
+            ("mixing_temperature", 80.0, "°C"),
+            ("mixing_time", 8, "h"),
+            ("gelation_time", 24, "h"),
+            ("final_drying", "vacuum_40C_6h", None)
+        ],
+        properties=[
+            ("ionic_conductivity", 1.8e-3, "S/cm"),  # Higher than first cell
+            ("thickness", 30, "µm"),
+            ("gel_fraction", 92, "%")
+        ]
+    )
+    
+    # CATHODE CURRENT COLLECTOR: Aluminum foil (different from SS in first cell)
+    cell_2.metadata.add_component(
+        name="cathode_current_collector",
+        materials=[
+            ("Aluminum foil", "current_collector", 100.0, "wt%")
+        ],
+        properties=[
+            ("thickness", 15, "µm"),
+            ("surface_treatment", "carbon_coating", None)
+        ]
+    )
+    
+    # HOUSING: Coin cell (different packaging)
+    cell_2.metadata.add_component(
+        name="housing",
+        materials=[
+            ("Stainless steel", "coin_cell_case", None, None)
+        ],
+        procedures=[
+            ("assembly_method", "crimping", None),
+            ("crimping_pressure", 1.5, "tons"),
+            ("sealing_gasket", "polypropylene", None)
+        ],
+        properties=[
+            ("case_diameter", 20, "mm"),
+            ("case_height", 3.2, "mm")
+        ]
+    )
+    
+    # Assembly notes
+    cell_2.metadata.add_note(
+        name="assembly_tool",
+        value="MSK-110 coin cell crimper"
+    )
+    
+    cell_2.metadata.add_note(
+        name="conditioning_protocol", 
+        value="12h at room temperature, then 4h at 40°C"
+    )
+    
+    print(f"\n✅ Second cell '{cell_2.metadata.id}' created")
+    print(f"   - {len(cell_2.metadata.components)} components")
+    print(f"   - Different: gel electrolyte, PTMA cathode, coin cell packaging")
+    
+    # =================================================================
+    # 8. TECHNIQUE 4: Electrochemical Impedance Spectroscopy
+    # =================================================================
+    eis_start = base_timestamp + timedelta(days=1, hours=2)  # Day after first cell tests
+    eis_end = eis_start + timedelta(minutes=45)
+    
+    eis_technique.metadata.id = 1
+    eis_technique.metadata.type = "Electrochemical Impedance Spectroscopy"
+    eis_technique.metadata.start = eis_start
+    eis_technique.metadata.end = eis_end
+    
+    # Different potentiostat for EIS
+    eis_technique.metadata.add_device(
+        name="Solartron_1470E",
+        type="potentiostat",
+        manufacturer="Solartron Analytical",
+        model="1470E",
+        software_name="CorrWare",
+        software_version="3.5c"
+    )
+    
+    # EIS parameters
+    eis_technique.metadata.add_setting("dc_potential", 1.5, "V")  # Open circuit
+    eis_technique.metadata.add_setting("ac_amplitude", 10, "mV")
+    eis_technique.metadata.add_setting("frequency_range_high", 100000, "Hz")
+    eis_technique.metadata.add_setting("frequency_range_low", 0.01, "Hz")
+    eis_technique.metadata.add_setting("points_per_decade", 10, None)
+    eis_technique.metadata.add_setting("integration_time", 5, "cycles")
+    eis_technique.metadata.add_setting("delay_before_measurement", 300, "s")
+    
+    eis_technique.metadata.add_note(
+        name="measurement_purpose",
+        value="Impedance characterization and equivalent circuit modeling"
+    )
+    
+    eis_technique.metadata.add_note(
+        name="measurement_mode",
+        value="potentiostatic"
+    )
+    
+    print(f"\n✅ EIS Technique created")
+    print(f"   - Duration: {eis_start.strftime('%H:%M')} - {eis_end.strftime('%H:%M')}")
+    print(f"   - Frequency range: 0.01 Hz - 100 kHz")
+    
+    # =================================================================
+    # 9. TECHNIQUE 5: Slow Scan Rate CV for second cell
+    # =================================================================
+    cv_slow_start = eis_end + timedelta(minutes=15)  # Short rest after EIS
+    cv_slow_end = cv_slow_start + timedelta(minutes=120)  # Very slow CV takes longer
+    
+    cv_slow_technique.metadata.id = 2
+    cv_slow_technique.metadata.type = "Cyclic Voltammetry"
+    cv_slow_technique.metadata.start = cv_slow_start
+    cv_slow_technique.metadata.end = cv_slow_end
+    
+    # Same potentiostat as EIS
+    cv_slow_technique.metadata.add_device(
+        name="Solartron_1470E",
+        type="potentiostat",
+        manufacturer="Solartron Analytical", 
+        model="1470E",
+        software_name="CorrWare",
+        software_version="3.5c"
+    )
+    
+    # Very slow CV parameters for detailed analysis
+    cv_slow_technique.metadata.add_setting("initial_potential", 1.0, "V")
+    cv_slow_technique.metadata.add_setting("initial_potential_hold", 60, "s")
+    cv_slow_technique.metadata.add_setting("vertex_potential_low", 0.5, "V")
+    cv_slow_technique.metadata.add_setting("vertex_potential_high", 2.0, "V")
+    cv_slow_technique.metadata.add_setting("scan_rate", 0.5, "mV/s")  # Very slow
+    cv_slow_technique.metadata.add_setting("cycle_count", 2, None)
+    cv_slow_technique.metadata.add_setting("current_range", 1, "mA")
+    cv_slow_technique.metadata.add_setting("potential_range", [-1.0, 3.0], "V")
+    
+    cv_slow_technique.metadata.add_note(
+        name="measurement_purpose",
+        value="High-resolution redox peak analysis and mechanistic studies"
+    )
+    
+    cv_slow_technique.metadata.add_note(
+        name="data_sampling",
+        value="high_resolution"
+    )
+    
+    print(f"\n✅ Slow CV Technique created")
+    print(f"   - Duration: {cv_slow_start.strftime('%H:%M')} - {cv_slow_end.strftime('%H:%M')}")
+    print(f"   - Ultra-slow scan rate: 0.5 mV/s")
+    
+    # =================================================================
+    # 10. AUXILIARY DATA: Pressure Monitoring for coin cell
+    # =================================================================
+    pressure_start = eis_start - timedelta(minutes=15)  # Start before EIS
+    pressure_end = cv_slow_end + timedelta(minutes=15)   # End after slow CV
+    
+    pressure_aux.metadata.id = 1
+    pressure_aux.metadata.type = "Pressure Monitoring"
+    pressure_aux.metadata.start = pressure_start
+    pressure_aux.metadata.end = pressure_end
+    pressure_aux.metadata.parent_techniques = [1, 2]  # Monitor during EIS and slow CV
+    # No group needed - single pressure auxiliary
+    
+    # Pressure monitoring equipment
+    pressure_aux.metadata.add_device(
+        name="Honeywell_26PC",
+        type="pressure_sensor",
+        manufacturer="Honeywell",
+        model="26PCAFA6G",
+        software_name="LabView_DAQ",
+        software_version="2023"
+    )
+    
+    pressure_aux.metadata.add_device(
+        name="DAQ_USB6009",
+        type="data_acquisition",
+        manufacturer="National Instruments",
+        model="USB-6009",
+        software_name="LabVIEW",
+        software_version="2023"
+    )
+    
+    # Pressure monitoring settings
+    pressure_aux.metadata.add_setting("sampling_rate", 0.1, "Hz")  # Slower than temperature
+    pressure_aux.metadata.add_setting("pressure_range_min", 0.8, "bar")
+    pressure_aux.metadata.add_setting("pressure_range_max", 1.2, "bar")
+    pressure_aux.metadata.add_setting("sensor_accuracy", 0.25, "%")
+    pressure_aux.metadata.add_setting("temperature_compensation", True, None)
+    
+    pressure_aux.metadata.add_setting("sensor_location", "environmental", None)
+    pressure_aux.metadata.add_setting("measurement_type", "absolute_pressure", None)
+    
+    pressure_aux.metadata.add_note(
+        name="measurement_purpose",
+        value="Environmental pressure monitoring for coin cell volume change correlation"
+    )
+    
+    print(f"\n✅ Pressure monitoring created") 
+    print(f"   - Duration: {pressure_start.strftime('%H:%M')} - {pressure_end.strftime('%H:%M')}")
+    print(f"   - Covers techniques: {pressure_aux.metadata.parent_techniques}")
+    
+    print(f"\n✅ Second cell added to file object")
+    print(f"   - File object now contains {len(my_first_study_file.cells)} cell(s)")
+    print(f"   - Total techniques: {sum(len(cell.techniques) for cell in my_first_study_file.cells.values())}")
+    print(f"   - Total auxiliaries: {sum(len(cell.auxiliary) for cell in my_first_study_file.cells.values())}")
+    
+    return my_first_study_file
+
+def demonstrate_metadata_access(file_object):
+    """Demonstrate find/modify functionality of the metadata system."""
+    
+    print("\n" + "="*60)
+    print("🔍 DEMONSTRATING METADATA ACCESS & MODIFICATION")
+    print("="*60)
+    
+    # Extract objects from file_object
+    study = file_object.metadata
+    cell = file_object.get_cell("cell_001")
+    cell_2 = file_object.get_cell("cell_002")
+    cv_tech = cell.get_technique("technique_001_CV")
+    cv_tech_2 = cell.get_technique("technique_002_CV")
+    gcd_tech = cell.get_technique("technique_003_GCD")
+    temp_aux = cell.get_auxiliary("auxiliary_001_temperature")
+    
+                # Second cell objects
+    eis_tech = cell_2.get_technique("technique_001_EIS")
+    cv_slow_tech = cell_2.get_technique("technique_002_CV")
+    pressure_aux = cell_2.get_auxiliary("auxiliary_001_pressure")
+    
+    # =================================================================
+    # Study-level access and modification
+    # =================================================================
+    print("\n📋 Study-level operations:")
+    
+    # Find and modify contributor
+    marcus = study.find_contributor("Marcus Weber")
+    if marcus:
+        original_email = marcus.email
+        marcus.email = "m.weber.phd@uni-jena.de"  # Updated email
+        marcus.add_additional_info("Thesis_Topic", "Polymer-Zinc Battery Systems")
+        print(f"   ✅ Updated Marcus's email: {original_email} → {marcus.email}")
+        print(f"   ✅ Added thesis topic: {marcus.additional_info[-1]['value']}")
+    
+    # Find funding and access details
+    dfg = study.find_funding("Deutsche Forschungsgemeinschaft (DFG)")
+    if dfg:
+        print(f"   ✅ Found DFG funding: {dfg.grant_number}")
+    
+    # =================================================================
+    # Cell-level nested access and modification  
+    # =================================================================
+    print("\n🔋 Cell-level nested operations:")
+    
+    # Find component and modify material
+    cathode = cell.metadata.find_component("cathode")
+    if cathode:
+        mno2 = cathode.find_material("Manganese dioxide")
+        if mno2:
+            original_value = mno2.amount.value
+            mno2.amount.value = 78.0  # Optimized composition
+            print(f"   ✅ Updated MnO2 content: {original_value}% → {mno2.amount.value}%")
+        
+        # Modify mixing speed
+        mixing_speed = cathode.find_procedure("mixing_speed")
+        if mixing_speed:
+            mixing_speed.value = 500  # Increased speed
+            print(f"   ✅ Updated mixing speed: {mixing_speed.value} {mixing_speed.unit}")
+        
+        # Modify mixing time
+        mixing_time = cathode.find_procedure("mixing_time") 
+        if mixing_time:
+            mixing_time.value = 3  # Extended time
+            print(f"   ✅ Extended mixing time: {mixing_time.value} {mixing_time.unit}")
+    
+    # Modify electrolyte composition
+    electrolyte = cell.metadata.find_component("electrolyte")
+    if electrolyte:
+        peo = electrolyte.find_material("Poly(ethylene oxide)")
+        li_salt = electrolyte.find_material("LiTFSI")
+        if peo and li_salt:
+            # Rebalance composition
+            peo.amount.value = 65.0
+            li_salt.amount.value = 20.0  # Reduced for better mechanical properties
+            print(f"   ✅ Rebalanced electrolyte: PEO {peo.amount.value}%, LiTFSI {li_salt.amount.value}%")
+    
+    # Update conditioning protocol
+    conditioning = cell.metadata.find_note("conditioning_protocol")
+    if conditioning:
+        conditioning.value = "48h at 60°C for enhanced electrolyte penetration"
+        print(f"   ✅ Extended conditioning time to 48h")
+    
+    # =================================================================
+    # Technique-level access and modification
+    # =================================================================
+    print("\n⚡ Technique-level operations:")
+    
+    # Modify CV settings
+    scan_rate = cv_tech.metadata.find_setting("scan_rate")
+    if scan_rate:
+        original_rate = scan_rate.value
+        scan_rate.value = 0.05  # Slower for better resolution
+        print(f"   ✅ CV scan rate: {original_rate} → {scan_rate.value} {scan_rate.unit}")
+    
+    # Modify cycle count
+    cycles = cv_tech.metadata.find_setting("cycle_count")
+    if cycles:
+        cycles.value = 3  # Reduced for preliminary test
+        print(f"   ✅ CV cycles reduced to: {cycles.value}")
+    
+    # Modify GCD parameters
+    upper_limit = gcd_tech.metadata.find_setting("voltage_limit_high") 
+    if upper_limit:
+        upper_limit.value = 2.05  # Slightly lower for safety
+        print(f"   ✅ GCD upper limit: {upper_limit.value} {upper_limit.unit}")
+    
+    # Update measurement purpose
+    cv_purpose = cv_tech.metadata.find_note("measurement_purpose")
+    if cv_purpose:
+        cv_purpose.value = "Preliminary electrochemical stability assessment"
+        print(f"   ✅ Updated CV measurement purpose")
+    
+    # =================================================================
+    # Auxiliary data access and modification
+    # =================================================================
+    print("\n🌡️  Auxiliary data operations:")
+    
+    # Modify temperature sampling
+    sampling_rate = temp_aux.metadata.find_setting("sampling_rate")
+    if sampling_rate:
+        sampling_rate.value = 0.5  # Reduce to save storage space
+        print(f"   ✅ Temperature sampling: {sampling_rate.value} {sampling_rate.unit}")
+    
+    # Update measurement purpose
+    temp_purpose = temp_aux.metadata.find_note("measurement_purpose")
+    if temp_purpose:
+        temp_purpose.value = "Cell thermal response monitoring during electrochemical testing"
+        print(f"   ✅ Updated temperature measurement purpose")
+    
+    # Find and modify device info
+    thermocouple = temp_aux.metadata.find_device("TC_Cell_Surface")
+    if thermocouple and thermocouple.software:
+        thermocouple.software.version = "2.2"  # Updated software
+        print(f"   ✅ Updated thermocouple software to v{thermocouple.software.version}")
+    
+    # =================================================================
+    # Second cell operations
+    # =================================================================
+    print("\n🔋 Second cell operations:")
+    
+    # Modify second cell electrolyte composition
+    gel_electrolyte = cell_2.metadata.find_component("electrolyte")
+    if gel_electrolyte:
+        pmma = gel_electrolyte.find_material("PMMA")  
+        if pmma:
+            pmma.amount.value = 50.0  # Increase polymer content
+            print(f"   ✅ Increased PMMA content to {pmma.amount.value}%")
+    
+    # Modify EIS settings
+    ac_amplitude = eis_tech.metadata.find_setting("ac_amplitude")
+    if ac_amplitude:
+        ac_amplitude.value = 5  # Reduce amplitude for better linearity
+        print(f"   ✅ EIS AC amplitude reduced to {ac_amplitude.value} {ac_amplitude.unit}")
+    
+    # Update slow CV purpose
+    slow_cv_purpose = cv_slow_tech.metadata.find_note("measurement_purpose")
+    if slow_cv_purpose:
+        slow_cv_purpose.value = "Ultra-high resolution mechanistic analysis of redox processes"
+        print(f"   ✅ Updated slow CV measurement purpose")
+    
+    # Modify pressure monitoring sampling
+    pressure_sampling = pressure_aux.metadata.find_setting("sampling_rate")
+    if pressure_sampling:
+        pressure_sampling.value = 0.05  # Even slower sampling
+        print(f"   ✅ Pressure sampling reduced to {pressure_sampling.value} {pressure_sampling.unit}")
+
+def demonstrate_serialization(file_object):
+    """Demonstrate serialization capabilities."""
+    
+    print("\n" + "="*60) 
+    print("💾 DEMONSTRATING SERIALIZATION & DATA EXPORT")
+    print("="*60)
+    
+    # Extract objects from file_object
+    study = file_object.metadata
+    cell = file_object.get_cell("cell_001")
+    cell_2 = file_object.get_cell("cell_002")
+    cv_tech = cell.get_technique("technique_001_CV")
+    cv_tech_2 = cell.get_technique("technique_002_CV")
+    gcd_tech = cell.get_technique("technique_003_GCD")
+    temp_aux = cell.get_auxiliary("auxiliary_001_temperature")
+    
+    # Second cell objects
+    eis_tech = cell_2.get_technique("technique_001_EIS")
+    cv_slow_tech = cell_2.get_technique("technique_002_CV")
+    pressure_aux = cell_2.get_auxiliary("auxiliary_001_pressure")
+    
+    # Study serialization
+    print("\n📊 Study metadata serialization:")
+    study_dict = study.to_dict()
+    print(f"   ✅ Dictionary: {len(study_dict)} top-level keys")
+    print(f"   ✅ Contributors: {len(study_dict['study_metadata']['contributors'])}")
+    print(f"   ✅ Funding sources: {len(study_dict['study_metadata']['funding'])}")
+    
+    study_attrs = study.to_netcdf_attrs()
+    print(f"   ✅ NetCDF attributes: {len(study_attrs)} attributes")
+    
+    # Cell serialization with nested structure
+    print("\n🔋 Cell metadata serialization:")
+    cell_dict = cell.metadata.to_dict()
+    tiers = list(cell_dict.keys())
+    print(f"   ✅ BDG tiers: {tiers}")
+    print(f"   ✅ Components: {len(cell_dict['secondary']['components'])}")
+    if 'tertiary' in cell_dict:
+        print(f"   ✅ Notes: {len(cell_dict['tertiary']['additional_notes'])}")
+    
+    # Show component detail
+    cathode_data = None
+    for comp in cell_dict['secondary']['components']:
+        if comp['name'] == 'cathode':
+            cathode_data = comp
+            break
+    
+    if cathode_data:
+        print(f"   ✅ Cathode materials: {len(cathode_data['materials'])}")
+        print(f"   ✅ Cathode procedures: {len(cathode_data['procedures'])}")
+        print(f"   ✅ Cathode properties: {len(cathode_data['properties'])}")
+    
+    # Show electrolyte detail
+    electrolyte_data = None
+    for comp in cell_dict['secondary']['components']:
+        if comp['name'] == 'electrolyte':
+            electrolyte_data = comp
+            break
+    
+    if electrolyte_data:
+        print(f"   ✅ Electrolyte materials: {len(electrolyte_data['materials'])}")
+        print(f"   ✅ Electrolyte procedures: {len(electrolyte_data['procedures'])}")
+    
+    # Technique serialization
+    print("\n⚡ Technique metadata serialization:")
+    cv_dict = cv_tech.metadata.to_dict()
+    gcd_dict = gcd_tech.metadata.to_dict()
+    
+    print(f"   ✅ CV settings: {len(cv_dict['secondary']['settings'])}")
+    print(f"   ✅ GCD settings: {len(gcd_dict['secondary']['settings'])}")
+    
+    # Auxiliary serialization  
+    print("\n🌡️  Auxiliary metadata serialization:")
+    temp_dict = temp_aux.metadata.to_dict()
+    print(f"   ✅ Temperature devices: {len(temp_dict['secondary']['devices'])}")
+    print(f"   ✅ Parent techniques: {temp_dict['primary']['parent_techniques']}")
+    
+    # Second cell serialization
+    print(f"\n🔋 Second cell metadata serialization:")
+    cell_2_dict = cell_2.metadata.to_dict()
+    print(f"   ✅ Second cell components: {len(cell_2_dict['secondary']['components'])}")
+    
+    # Show gel electrolyte detail
+    gel_electrolyte_data = None
+    for comp in cell_2_dict['secondary']['components']:
+        if comp['name'] == 'electrolyte':
+            gel_electrolyte_data = comp
+            break
+    
+    if gel_electrolyte_data:
+        print(f"   ✅ Gel electrolyte materials: {len(gel_electrolyte_data['materials'])}")
+        print(f"   ✅ Gel electrolyte procedures: {len(gel_electrolyte_data['procedures'])}")
+    
+    # EIS technique serialization
+    print(f"\n⚡ EIS technique serialization:")
+    eis_dict = eis_tech.metadata.to_dict()
+    print(f"   ✅ EIS settings: {len(eis_dict['secondary']['settings'])}")
+    
+    # Pressure auxiliary serialization
+    print(f"\n📊 Second auxiliary serialization:")
+    pressure_dict = pressure_aux.metadata.to_dict()
+    print(f"   ✅ Pressure devices: {len(pressure_dict['secondary']['devices'])}")
+    
+    # JSON export demonstration
+    print(f"\n📄 JSON export samples:")
+    print(f"   Study JSON: {len(study.to_json())} characters")
+    print(f"   Cell 1 JSON: {len(cell.metadata.to_json())} characters")
+    print(f"   Cell 2 JSON: {len(cell_2.metadata.to_json())} characters")
+    
+    # Show small sample of actual JSON structure
+    print(f"\n   Study JSON structure preview:")
+    study_json = json.loads(study.to_json())
+    print(f"   {json.dumps(study_json['file_metadata'], indent=6)}")
+
+def demonstrate_structure_visualization(file_object):
+    """Demonstrate the new structure visualization capabilities."""
+    
+    print("\n" + "="*60)
+    print("🎨 DEMONSTRATING STRUCTURE VISUALIZATION")
+    print("="*60)
+    
+    # Simplified version
+    print("\n📟 Simplified Structure Visualization:")
+    print("-" * 40)
+    file_object.print_structure(show_metadata=False, show_data=False)
+    
+    # Detailed version
+    print("\n📟 Detailed Structure Visualization:")
+    print("-" * 40)
+    file_object.print_structure(show_metadata=True, show_data=False)
+    
+    # Try graphical visualization  
+    print("\n🎨 Graphical Structure Visualization:")
+    print("-" * 40)
+    
+    # Graphical visualization
+    print("📊 Creating entity relationship diagrams...")
+    try:
+        file_object.plot_structure(
+            filename="polymer_structure_detailed", 
+            format="svg",
+            show_metadata=True
+        )
+
+        file_object.plot_structure(
+            filename="polymer_structure_simple",
+            format="svg", 
+            show_metadata=False
+        )
+        
+    except Exception as e:
+        print(f"⚠️  Visualization failed: {e}")
+
+
+
+
+
+def main():
+    """Main demonstration function."""
+    
+    print("🧬 COMPREHENSIVE POLYMER/ZINC BATTERY METADATA DEMONSTRATION")
+    print("Using the new echem_data_tool")
+    print("="*80)
+    
+    # Create complete study metadata
+    my_first_study_file = create_polymer_zinc_study()
+    
+    # Demonstrate access and modification capabilities
+    demonstrate_metadata_access(my_first_study_file)
+    
+    # Demonstrate serialization and export
+    demonstrate_serialization(my_first_study_file)
+    
+    # Demonstrate structure visualization
+    demonstrate_structure_visualization(my_first_study_file)
+    
+if __name__ == "__main__":
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -28,6 +28,107 @@ files = [
 dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
 
 [[package]]
+name = "certifi"
+version = "2025.10.5"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de"},
+    {file = "certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"},
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.3"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "charset_normalizer-3.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fb7f67a1bfa6e40b438170ebdc8158b78dc465a5a67b6dde178a46987b244a72"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc9370a2da1ac13f0153780040f465839e6cccb4a1e44810124b4e22483c93fe"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:07a0eae9e2787b586e129fdcbe1af6997f8d0e5abaa0bc98c0e20e124d67e601"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:74d77e25adda8581ffc1c720f1c81ca082921329452eba58b16233ab1842141c"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0e909868420b7049dafd3a31d45125b31143eec59235311fc4c57ea26a4acd2"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c6f162aabe9a91a309510d74eeb6507fab5fff92337a15acbe77753d88d9dcf0"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4ca4c094de7771a98d7fbd67d9e5dbf1eb73efa4f744a730437d8a3a5cf994f0"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:02425242e96bcf29a49711b0ca9f37e451da7c70562bc10e8ed992a5a7a25cc0"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:78deba4d8f9590fe4dae384aeff04082510a709957e968753ff3c48399f6f92a"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-win32.whl", hash = "sha256:d79c198e27580c8e958906f803e63cddb77653731be08851c7df0b1a14a8fc0f"},
+    {file = "charset_normalizer-3.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:c6e490913a46fa054e03699c70019ab869e990270597018cef1d8562132c2669"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b256ee2e749283ef3ddcff51a675ff43798d92d746d1a6e4631bf8c707d22d0b"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13faeacfe61784e2559e690fc53fa4c5ae97c6fcedb8eb6fb8d0a15b475d2c64"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:00237675befef519d9af72169d8604a067d92755e84fe76492fef5441db05b91"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:585f3b2a80fbd26b048a0be90c5aae8f06605d3c92615911c3a2b03a8a3b796f"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e78314bdc32fa80696f72fa16dc61168fda4d6a0c014e0380f9d02f0e5d8a07"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:96b2b3d1a83ad55310de8c7b4a2d04d9277d5591f40761274856635acc5fcb30"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:939578d9d8fd4299220161fdd76e86c6a251987476f5243e8864a7844476ba14"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:fd10de089bcdcd1be95a2f73dbe6254798ec1bda9f450d5828c96f93e2536b9c"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1e8ac75d72fa3775e0b7cb7e4629cec13b7514d928d15ef8ea06bca03ef01cae"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-win32.whl", hash = "sha256:6cf8fd4c04756b6b60146d98cd8a77d0cdae0e1ca20329da2ac85eed779b6849"},
+    {file = "charset_normalizer-3.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:31a9a6f775f9bcd865d88ee350f0ffb0e25936a7f930ca98995c05abf1faf21c"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-win32.whl", hash = "sha256:fb6fecfd65564f208cbf0fba07f107fb661bcd1a7c389edbced3f7a493f70e37"},
+    {file = "charset_normalizer-3.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:86df271bf921c2ee3818f0522e9a5b8092ca2ad8b065ece5d7d9d0e9f4849bcc"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce"},
+    {file = "charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce"},
+    {file = "charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:0f2be7e0cf7754b9a30eb01f4295cc3d4358a479843b31f328afd210e2c7598c"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c60e092517a73c632ec38e290eba714e9627abe9d301c8c8a12ec32c314a2a4b"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:252098c8c7a873e17dd696ed98bbe91dbacd571da4b87df3736768efa7a792e4"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3653fad4fe3ed447a596ae8638b437f827234f01a8cd801842e43f3d0a6b281b"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8999f965f922ae054125286faf9f11bc6932184b93011d138925a1773830bbe9"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d95bfb53c211b57198bb91c46dd5a2d8018b3af446583aab40074bf7988401cb"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:5b413b0b1bfd94dbf4023ad6945889f374cd24e3f62de58d6bb102c4d9ae534a"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:b5e3b2d152e74e100a9e9573837aba24aab611d39428ded46f4e4022ea7d1942"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a2d08ac246bb48479170408d6c19f6385fa743e7157d716e144cad849b2dd94b"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-win32.whl", hash = "sha256:ec557499516fc90fd374bf2e32349a2887a876fbf162c160e3c01b6849eaf557"},
+    {file = "charset_normalizer-3.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:5d8d01eac18c423815ed4f4a2ec3b439d654e55ee4ad610e153cf02faf67ea40"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:70bfc5f2c318afece2f5838ea5e4c3febada0be750fcf4775641052bbba14d05"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23b6b24d74478dc833444cbd927c338349d6ae852ba53a0d02a2de1fce45b96e"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:34a7f768e3f985abdb42841e20e17b330ad3aaf4bb7e7aeeb73db2e70f077b99"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb731e5deb0c7ef82d698b0f4c5bb724633ee2a489401594c5c88b02e6cb15f7"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:257f26fed7d7ff59921b78244f3cd93ed2af1800ff048c33f624c87475819dd7"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1ef99f0456d3d46a50945c98de1774da86f8e992ab5c77865ea8b8195341fc19"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2c322db9c8c89009a990ef07c3bcc9f011a3269bc06782f916cd3d9eed7c9312"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:511729f456829ef86ac41ca78c63a5cb55240ed23b4b737faca0eb1abb1c41bc"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:88ab34806dea0671532d3f82d82b85e8fc23d7b2dd12fa837978dad9bb392a34"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-win32.whl", hash = "sha256:16a8770207946ac75703458e2c743631c79c59c5890c80011d536248f8eaa432"},
+    {file = "charset_normalizer-3.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:d22dbedd33326a4a5190dd4fe9e9e693ef12160c77382d9e87919bce54f3d4ca"},
+    {file = "charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a"},
+    {file = "charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14"},
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -170,6 +271,21 @@ files = [
 numpy = ">=1.19.3"
 
 [[package]]
+name = "idna"
+version = "3.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
@@ -203,75 +319,118 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "markupsafe"
-version = "3.0.2"
+version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"dev\""
 files = [
-    {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50"},
-    {file = "MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d"},
-    {file = "MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30"},
-    {file = "MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6"},
-    {file = "MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f"},
-    {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
-    {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
+    {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
+    {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1"},
+    {file = "markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad"},
+    {file = "markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c"},
+    {file = "markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e"},
+    {file = "markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f"},
+    {file = "markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795"},
+    {file = "markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287"},
+    {file = "markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe"},
+    {file = "markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa"},
+    {file = "markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26"},
+    {file = "markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8"},
+    {file = "markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"},
 ]
+
+[[package]]
+name = "mermaid-py"
+version = "0.8.0"
+description = "Python Interface for the Popular mermaid-js Library, Simplified for Diagram Creation."
+optional = false
+python-versions = "<4.0,>=3.9"
+groups = ["main"]
+files = [
+    {file = "mermaid_py-0.8.0-py3-none-any.whl", hash = "sha256:dab0463ffe67fb3f13f0058cf5c0c2fa2685136cdc7e4ae3067d8b9d9c9e378a"},
+    {file = "mermaid_py-0.8.0.tar.gz", hash = "sha256:8ba7853f88c09ebf9c2d355c0ebd1e272e877c9568c10612ae9d0f57245608ef"},
+]
+
+[package.dependencies]
+requests = ">=2.31.0,<3.0.0"
 
 [[package]]
 name = "numpy"
@@ -401,54 +560,67 @@ files = [
 
 [[package]]
 name = "pandas"
-version = "2.3.2"
+version = "2.3.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pandas-2.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52bc29a946304c360561974c6542d1dd628ddafa69134a7131fdfd6a5d7a1a35"},
-    {file = "pandas-2.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:220cc5c35ffaa764dd5bb17cf42df283b5cb7fdf49e10a7b053a06c9cb48ee2b"},
-    {file = "pandas-2.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c05e15111221384019897df20c6fe893b2f697d03c811ee67ec9e0bb5a3424"},
-    {file = "pandas-2.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc03acc273c5515ab69f898df99d9d4f12c4d70dbfc24c3acc6203751d0804cf"},
-    {file = "pandas-2.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d25c20a03e8870f6339bcf67281b946bd20b86f1a544ebbebb87e66a8d642cba"},
-    {file = "pandas-2.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:21bb612d148bb5860b7eb2c10faacf1a810799245afd342cf297d7551513fbb6"},
-    {file = "pandas-2.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:b62d586eb25cb8cb70a5746a378fc3194cb7f11ea77170d59f889f5dfe3cec7a"},
-    {file = "pandas-2.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1333e9c299adcbb68ee89a9bb568fc3f20f9cbb419f1dd5225071e6cddb2a743"},
-    {file = "pandas-2.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:76972bcbd7de8e91ad5f0ca884a9f2c477a2125354af624e022c49e5bd0dfff4"},
-    {file = "pandas-2.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b98bdd7c456a05eef7cd21fd6b29e3ca243591fe531c62be94a2cc987efb5ac2"},
-    {file = "pandas-2.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d81573b3f7db40d020983f78721e9bfc425f411e616ef019a10ebf597aedb2e"},
-    {file = "pandas-2.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e190b738675a73b581736cc8ec71ae113d6c3768d0bd18bffa5b9a0927b0b6ea"},
-    {file = "pandas-2.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c253828cb08f47488d60f43c5fc95114c771bbfff085da54bfc79cb4f9e3a372"},
-    {file = "pandas-2.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:9467697b8083f9667b212633ad6aa4ab32436dcbaf4cd57325debb0ddef2012f"},
-    {file = "pandas-2.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fbb977f802156e7a3f829e9d1d5398f6192375a3e2d1a9ee0803e35fe70a2b9"},
-    {file = "pandas-2.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b9b52693123dd234b7c985c68b709b0b009f4521000d0525f2b95c22f15944b"},
-    {file = "pandas-2.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bd281310d4f412733f319a5bc552f86d62cddc5f51d2e392c8787335c994175"},
-    {file = "pandas-2.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96d31a6b4354e3b9b8a2c848af75d31da390657e3ac6f30c05c82068b9ed79b9"},
-    {file = "pandas-2.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:df4df0b9d02bb873a106971bb85d448378ef14b86ba96f035f50bbd3688456b4"},
-    {file = "pandas-2.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:213a5adf93d020b74327cb2c1b842884dbdd37f895f42dcc2f09d451d949f811"},
-    {file = "pandas-2.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:8c13b81a9347eb8c7548f53fd9a4f08d4dfe996836543f805c987bafa03317ae"},
-    {file = "pandas-2.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0c6ecbac99a354a051ef21c5307601093cb9e0f4b1855984a084bfec9302699e"},
-    {file = "pandas-2.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c6f048aa0fd080d6a06cc7e7537c09b53be6642d330ac6f54a600c3ace857ee9"},
-    {file = "pandas-2.3.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0064187b80a5be6f2f9c9d6bdde29372468751dfa89f4211a3c5871854cfbf7a"},
-    {file = "pandas-2.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ac8c320bded4718b298281339c1a50fb00a6ba78cb2a63521c39bec95b0209b"},
-    {file = "pandas-2.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:114c2fe4f4328cf98ce5716d1532f3ab79c5919f95a9cfee81d9140064a2e4d6"},
-    {file = "pandas-2.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:48fa91c4dfb3b2b9bfdb5c24cd3567575f4e13f9636810462ffed8925352be5a"},
-    {file = "pandas-2.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:12d039facec710f7ba305786837d0225a3444af7bbd9c15c32ca2d40d157ed8b"},
-    {file = "pandas-2.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c624b615ce97864eb588779ed4046186f967374185c047070545253a52ab2d57"},
-    {file = "pandas-2.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0cee69d583b9b128823d9514171cabb6861e09409af805b54459bd0c821a35c2"},
-    {file = "pandas-2.3.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2319656ed81124982900b4c37f0e0c58c015af9a7bbc62342ba5ad07ace82ba9"},
-    {file = "pandas-2.3.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b37205ad6f00d52f16b6d09f406434ba928c1a1966e2771006a9033c736d30d2"},
-    {file = "pandas-2.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:837248b4fc3a9b83b9c6214699a13f069dc13510a6a6d7f9ba33145d2841a012"},
-    {file = "pandas-2.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d2c3554bd31b731cd6490d94a28f3abb8dd770634a9e06eb6d2911b9827db370"},
-    {file = "pandas-2.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:88080a0ff8a55eac9c84e3ff3c7665b3b5476c6fbc484775ca1910ce1c3e0b87"},
-    {file = "pandas-2.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d4a558c7620340a0931828d8065688b3cc5b4c8eb674bcaf33d18ff4a6870b4a"},
-    {file = "pandas-2.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45178cf09d1858a1509dc73ec261bf5b25a625a389b65be2e47b559905f0ab6a"},
-    {file = "pandas-2.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77cefe00e1b210f9c76c697fedd8fdb8d3dd86563e9c8adc9fa72b90f5e9e4c2"},
-    {file = "pandas-2.3.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:13bd629c653856f00c53dc495191baa59bcafbbf54860a46ecc50d3a88421a96"},
-    {file = "pandas-2.3.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:36d627906fd44b5fd63c943264e11e96e923f8de77d6016dc2f667b9ad193438"},
-    {file = "pandas-2.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:a9d7ec92d71a420185dec44909c32e9a362248c4ae2238234b76d5be37f208cc"},
-    {file = "pandas-2.3.2.tar.gz", hash = "sha256:ab7b58f8f82706890924ccdfb5f48002b83d2b5a3845976a9fb705d36c34dcdb"},
+    {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
+    {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
+    {file = "pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1"},
+    {file = "pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838"},
+    {file = "pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250"},
+    {file = "pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4"},
+    {file = "pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826"},
+    {file = "pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523"},
+    {file = "pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45"},
+    {file = "pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66"},
+    {file = "pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b"},
+    {file = "pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791"},
+    {file = "pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151"},
+    {file = "pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c"},
+    {file = "pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53"},
+    {file = "pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35"},
+    {file = "pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908"},
+    {file = "pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89"},
+    {file = "pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98"},
+    {file = "pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084"},
+    {file = "pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b"},
+    {file = "pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713"},
+    {file = "pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8"},
+    {file = "pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d"},
+    {file = "pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac"},
+    {file = "pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c"},
+    {file = "pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493"},
+    {file = "pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee"},
+    {file = "pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5"},
+    {file = "pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21"},
+    {file = "pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78"},
+    {file = "pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110"},
+    {file = "pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86"},
+    {file = "pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc"},
+    {file = "pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0"},
+    {file = "pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593"},
+    {file = "pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c"},
+    {file = "pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b"},
+    {file = "pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6"},
+    {file = "pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3"},
+    {file = "pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5"},
+    {file = "pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec"},
+    {file = "pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7"},
+    {file = "pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450"},
+    {file = "pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5"},
+    {file = "pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788"},
+    {file = "pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87"},
+    {file = "pandas-2.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c503ba5216814e295f40711470446bc3fd00f0faea8a086cbc688808e26f92a2"},
+    {file = "pandas-2.3.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a637c5cdfa04b6d6e2ecedcb81fc52ffb0fd78ce2ebccc9ea964df9f658de8c8"},
+    {file = "pandas-2.3.3-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:854d00d556406bffe66a4c0802f334c9ad5a96b4f1f868adf036a21b11ef13ff"},
+    {file = "pandas-2.3.3-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf1f8a81d04ca90e32a0aceb819d34dbd378a98bf923b6398b9a3ec0bf44de29"},
+    {file = "pandas-2.3.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:23ebd657a4d38268c7dfbdf089fbc31ea709d82e4923c5ffd4fbd5747133ce73"},
+    {file = "pandas-2.3.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5554c929ccc317d41a5e3d1234f3be588248e61f08a74dd17c9eabb535777dc9"},
+    {file = "pandas-2.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:d3e28b3e83862ccf4d85ff19cf8c20b2ae7e503881711ff2d534dc8f761131aa"},
+    {file = "pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b"},
 ]
 
 [package.dependencies]
@@ -596,21 +768,21 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.9"
+version = "2.12.0"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2"},
-    {file = "pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2"},
+    {file = "pydantic-2.12.0-py3-none-any.whl", hash = "sha256:f6a1da352d42790537e95e83a8bdfb91c7efbae63ffd0b86fa823899e807116f"},
+    {file = "pydantic-2.12.0.tar.gz", hash = "sha256:c1a077e6270dbfb37bfd8b498b3981e2bb18f68103720e51fa6c306a5a9af563"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
-pydantic-core = "2.33.2"
-typing-extensions = ">=4.12.2"
-typing-inspection = ">=0.4.0"
+pydantic-core = "2.41.1"
+typing-extensions = ">=4.14.1"
+typing-inspection = ">=0.4.2"
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
@@ -618,115 +790,129 @@ timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows
 
 [[package]]
 name = "pydantic-core"
-version = "2.33.2"
+version = "2.41.1"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0069c9acc3f3981b9ff4cdfaf088e98d83440a4c7ea1bc07460af3d4dc22e72d"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d53b22f2032c42eaaf025f7c40c2e3b94568ae077a606f006d206a463bc69572"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0405262705a123b7ce9f0b92f123334d67b70fd1f20a9372b907ce1080c7ba02"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b25d91e288e2c4e0662b8038a28c6a07eaac3e196cfc4ff69de4ea3db992a1b"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bdfe4b3789761f3bcb4b1ddf33355a71079858958e3a552f16d5af19768fef2"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:efec8db3266b76ef9607c2c4c419bdb06bf335ae433b80816089ea7585816f6a"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:031c57d67ca86902726e0fae2214ce6770bbe2f710dc33063187a68744a5ecac"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:f8de619080e944347f5f20de29a975c2d815d9ddd8be9b9b7268e2e3ef68605a"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73662edf539e72a9440129f231ed3757faab89630d291b784ca99237fb94db2b"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-win32.whl", hash = "sha256:0a39979dcbb70998b0e505fb1556a1d550a0781463ce84ebf915ba293ccb7e22"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-win_amd64.whl", hash = "sha256:b0379a2b24882fef529ec3b4987cb5d003b9cda32256024e6fe1586ac45fc640"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9"},
-    {file = "pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac"},
-    {file = "pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5"},
-    {file = "pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a2b911a5b90e0374d03813674bf0a5fbbb7741570dcd4b4e85a2e48d17def29d"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6fa6dfc3e4d1f734a34710f391ae822e0a8eb8559a85c6979e14e65ee6ba2954"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c54c939ee22dc8e2d545da79fc5381f1c020d6d3141d3bd747eab59164dc89fb"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53a57d2ed685940a504248187d5685e49eb5eef0f696853647bf37c418c538f7"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09fb9dd6571aacd023fe6aaca316bd01cf60ab27240d7eb39ebd66a3a15293b4"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e6116757f7959a712db11f3e9c0a99ade00a5bbedae83cb801985aa154f071b"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d55ab81c57b8ff8548c3e4947f119551253f4e3787a7bbc0b6b3ca47498a9d3"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c20c462aa4434b33a2661701b861604913f912254e441ab8d78d30485736115a"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44857c3227d3fb5e753d5fe4a3420d6376fa594b07b621e220cd93703fe21782"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:eb9b459ca4df0e5c87deb59d37377461a538852765293f9e6ee834f0435a93b9"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9fcd347d2cc5c23b06de6d3b7b8275be558a0c90549495c699e379a80bf8379e"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-win32.whl", hash = "sha256:83aa99b1285bc8f038941ddf598501a86f1536789740991d7d8756e34f1e74d9"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-win_amd64.whl", hash = "sha256:f481959862f57f29601ccced557cc2e817bce7533ab8e01a797a48b49c9692b3"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa9d91b338f2df0508606f7009fde642391425189bba6d8c653afd80fd6bb64e"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2058a32994f1fde4ca0480ab9d1e75a0e8c87c22b53a3ae66554f9af78f2fe8c"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:0e03262ab796d986f978f79c943fc5f620381be7287148b8010b4097f79a39ec"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:1a8695a8d00c73e50bff9dfda4d540b7dee29ff9b8053e38380426a85ef10052"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fa754d1850735a0b0e03bcffd9d4b4343eb417e47196e4485d9cca326073a42c"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a11c8d26a50bfab49002947d3d237abe4d9e4b5bdc8846a63537b6488e197808"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:87acbfcf8e90ca885206e98359d7dca4bcbb35abdc0ff66672a293e1d7a19101"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f92c15cd1e97d4b12acd1cc9004fa092578acfa57b67ad5e43a197175d01a64"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f26877a748dc4251cfcfda9dfb5f13fcb034f5308388066bcfe9031b63ae7d"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac89aea9af8cd672fa7b510e7b8c33b0bba9a43186680550ccf23020f32d535"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:970919794d126ba8645f3837ab6046fb4e72bbc057b3709144066204c19a455d"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3eb3fe62804e8f859c49ed20a8451342de53ed764150cb14ca71357c765dc2a6"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:3abcd9392a36025e3bd55f9bd38d908bd17962cc49bc6da8e7e96285336e2bca"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3a1c81334778f9e3af2f8aeb7a960736e5cab1dfebfb26aabca09afd2906c039"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27"},
-    {file = "pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e63036298322e9aea1c8b7c0a6c1204d615dbf6ec0668ce5b83ff27f07404a61"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:241299ca91fc77ef64f11ed909d2d9220a01834e8e6f8de61275c4dd16b7c936"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ab7e594a2a5c24ab8013a7dc8cfe5f2260e80e490685814122081705c2cf2b0"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b054ef1a78519cb934b58e9c90c09e93b837c935dcd907b891f2b265b129eb6e"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f2ab7d10d0ab2ed6da54c757233eb0f48ebfb4f86e9b88ccecb3f92bbd61a538"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2757606b7948bb853a27e4040820306eaa0ccb9e8f9f8a0fa40cb674e170f350"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cec0e75eb61f606bad0a32f2be87507087514e26e8c73db6cbdb8371ccd27917"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0234236514f44a5bf552105cfe2543a12f48203397d9d0f866affa569345a5b5"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1b974e41adfbb4ebb0f65fc4ca951347b17463d60893ba7d5f7b9bb087c83897"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:248dafb3204136113c383e91a4d815269f51562b6659b756cf3df14eefc7d0bb"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:678f9d76a91d6bcedd7568bbf6beb77ae8447f85d1aeebaab7e2f0829cfc3a13"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-win32.whl", hash = "sha256:dff5bee1d21ee58277900692a641925d2dddfde65182c972569b1a276d2ac8fb"},
+    {file = "pydantic_core-2.41.1-cp310-cp310-win_amd64.whl", hash = "sha256:5042da12e5d97d215f91567110fdfa2e2595a25f17c19b9ff024f31c34f9b53e"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4f276a6134fe1fc1daa692642a3eaa2b7b858599c49a7610816388f5e37566a1"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:07588570a805296ece009c59d9a679dc08fab72fb337365afb4f3a14cfbfc176"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28527e4b53400cd60ffbd9812ccb2b5135d042129716d71afd7e45bf42b855c0"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46a1c935c9228bad738c8a41de06478770927baedf581d172494ab36a6b96575"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:447ddf56e2b7d28d200d3e9eafa936fe40485744b5a824b67039937580b3cb20"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63892ead40c1160ac860b5debcc95c95c5a0035e543a8b5a4eac70dd22e995f4"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4a9543ca355e6df8fbe9c83e9faab707701e9103ae857ecb40f1c0cf8b0e94d"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f2611bdb694116c31e551ed82e20e39a90bea9b7ad9e54aaf2d045ad621aa7a1"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fecc130893a9b5f7bfe230be1bb8c61fe66a19db8ab704f808cb25a82aad0bc9"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:1e2df5f8344c99b6ea5219f00fdc8950b8e6f2c422fbc1cc122ec8641fac85a1"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:35291331e9d8ed94c257bab6be1cb3a380b5eee570a2784bffc055e18040a2ea"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-win32.whl", hash = "sha256:2876a095292668d753f1a868c4a57c4ac9f6acbd8edda8debe4218d5848cf42f"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-win_amd64.whl", hash = "sha256:b92d6c628e9a338846a28dfe3fcdc1a3279388624597898b105e078cdfc59298"},
+    {file = "pydantic_core-2.41.1-cp311-cp311-win_arm64.whl", hash = "sha256:7d82ae99409eb69d507a89835488fb657faa03ff9968a9379567b0d2e2e56bc5"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:db2f82c0ccbce8f021ad304ce35cbe02aa2f95f215cac388eed542b03b4d5eb4"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47694a31c710ced9205d5f1e7e8af3ca57cbb8a503d98cb9e33e27c97a501601"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e9decce94daf47baf9e9d392f5f2557e783085f7c5e522011545d9d6858e00"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ab0adafdf2b89c8b84f847780a119437a0931eca469f7b44d356f2b426dd9741"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5da98cc81873f39fd56882e1569c4677940fbc12bce6213fad1ead784192d7c8"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:209910e88afb01fd0fd403947b809ba8dba0e08a095e1f703294fda0a8fdca51"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365109d1165d78d98e33c5bfd815a9b5d7d070f578caefaabcc5771825b4ecb5"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:706abf21e60a2857acdb09502bc853ee5bce732955e7b723b10311114f033115"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bf0bd5417acf7f6a7ec3b53f2109f587be176cb35f9cf016da87e6017437a72d"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2e71b1c6ceb9c78424ae9f63a07292fb769fb890a4e7efca5554c47f33a60ea5"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:80745b9770b4a38c25015b517451c817799bfb9d6499b0d13d8227ec941cb513"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-win32.whl", hash = "sha256:83b64d70520e7890453f1aa21d66fda44e7b35f1cfea95adf7b4289a51e2b479"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-win_amd64.whl", hash = "sha256:377defd66ee2003748ee93c52bcef2d14fde48fe28a0b156f88c3dbf9bc49a50"},
+    {file = "pydantic_core-2.41.1-cp312-cp312-win_arm64.whl", hash = "sha256:c95caff279d49c1d6cdfe2996e6c2ad712571d3b9caaa209a404426c326c4bde"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:70e790fce5f05204ef4403159857bfcd587779da78627b0babb3654f75361ebf"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9cebf1ca35f10930612d60bd0f78adfacee824c30a880e3534ba02c207cceceb"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:170406a37a5bc82c22c3274616bf6f17cc7df9c4a0a0a50449e559cb755db669"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12d4257fc9187a0ccd41b8b327d6a4e57281ab75e11dda66a9148ef2e1fb712f"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a75a33b4db105dd1c8d57839e17ee12db8d5ad18209e792fa325dbb4baeb00f4"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08a589f850803a74e0fcb16a72081cafb0d72a3cdda500106942b07e76b7bf62"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a97939d6ea44763c456bd8a617ceada2c9b96bb5b8ab3dfa0d0827df7619014"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d2ae423c65c556f09569524b80ffd11babff61f33055ef9773d7c9fabc11ed8d"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:4dc703015fbf8764d6a8001c327a87f1823b7328d40b47ce6000c65918ad2b4f"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:968e4ffdfd35698a5fe659e5e44c508b53664870a8e61c8f9d24d3d145d30257"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:fff2b76c8e172d34771cd4d4f0ade08072385310f214f823b5a6ad4006890d32"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-win32.whl", hash = "sha256:a38a5263185407ceb599f2f035faf4589d57e73c7146d64f10577f6449e8171d"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-win_amd64.whl", hash = "sha256:b42ae7fd6760782c975897e1fdc810f483b021b32245b0105d40f6e7a3803e4b"},
+    {file = "pydantic_core-2.41.1-cp313-cp313-win_arm64.whl", hash = "sha256:ad4111acc63b7384e205c27a2f15e23ac0ee21a9d77ad6f2e9cb516ec90965fb"},
+    {file = "pydantic_core-2.41.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:440d0df7415b50084a4ba9d870480c16c5f67c0d1d4d5119e3f70925533a0edc"},
+    {file = "pydantic_core-2.41.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71eaa38d342099405dae6484216dcf1e8e4b0bebd9b44a4e08c9b43db6a2ab67"},
+    {file = "pydantic_core-2.41.1-cp313-cp313t-win_amd64.whl", hash = "sha256:555ecf7e50f1161d3f693bc49f23c82cf6cdeafc71fa37a06120772a09a38795"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:05226894a26f6f27e1deb735d7308f74ef5fa3a6de3e0135bb66cdcaee88f64b"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:85ff7911c6c3e2fd8d3779c50925f6406d770ea58ea6dde9c230d35b52b16b4a"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47f1f642a205687d59b52dc1a9a607f45e588f5a2e9eeae05edd80c7a8c47674"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df11c24e138876ace5ec6043e5cae925e34cf38af1a1b3d63589e8f7b5f5cdc4"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f0bf7f5c8f7bf345c527e8a0d72d6b26eda99c1227b0c34e7e59e181260de31"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82b887a711d341c2c47352375d73b029418f55b20bd7815446d175a70effa706"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5f1d5d6bbba484bdf220c72d8ecd0be460f4bd4c5e534a541bb2cd57589fb8b"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2bf1917385ebe0f968dc5c6ab1375886d56992b93ddfe6bf52bff575d03662be"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:4f94f3ab188f44b9a73f7295663f3ecb8f2e2dd03a69c8f2ead50d37785ecb04"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:3925446673641d37c30bd84a9d597e49f72eacee8b43322c8999fa17d5ae5bc4"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:49bd51cc27adb980c7b97357ae036ce9b3c4d0bb406e84fbe16fb2d368b602a8"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-win32.whl", hash = "sha256:a31ca0cd0e4d12ea0df0077df2d487fc3eb9d7f96bbb13c3c5b88dcc21d05159"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-win_amd64.whl", hash = "sha256:1b5c4374a152e10a22175d7790e644fbd8ff58418890e07e2073ff9d4414efae"},
+    {file = "pydantic_core-2.41.1-cp314-cp314-win_arm64.whl", hash = "sha256:4fee76d757639b493eb600fba668f1e17475af34c17dd61db7a47e824d464ca9"},
+    {file = "pydantic_core-2.41.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f9b9c968cfe5cd576fdd7361f47f27adeb120517e637d1b189eea1c3ece573f4"},
+    {file = "pydantic_core-2.41.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1ebc7ab67b856384aba09ed74e3e977dded40e693de18a4f197c67d0d4e6d8e"},
+    {file = "pydantic_core-2.41.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8ae0dc57b62a762985bc7fbf636be3412394acc0ddb4ade07fe104230f1b9762"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:10ce489cf09a4956a1549af839b983edc59b0f60e1b068c21b10154e58f54f80"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ff548c908caffd9455fd1342366bcf8a1ec8a3fca42f35c7fc60883d6a901074"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d43bf082025082bda13be89a5f876cc2386b7727c7b322be2d2b706a45cea8e"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:666aee751faf1c6864b2db795775dd67b61fdcf646abefa309ed1da039a97209"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b83aaeff0d7bde852c32e856f3ee410842ebc08bc55c510771d87dcd1c01e1ed"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:055c7931b0329cb8acde20cdde6d9c2cbc2a02a0a8e54a792cddd91e2ea92c65"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530bbb1347e3e5ca13a91ac087c4971d7da09630ef8febd27a20a10800c2d06d"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:65a0ea16cfea7bfa9e43604c8bd726e63a3788b61c384c37664b55209fcb1d74"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8fa93fadff794c6d15c345c560513b160197342275c6d104cc879f932b978afc"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:c8a1af9ac51969a494c6a82b563abae6859dc082d3b999e8fa7ba5ee1b05e8e8"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:30edab28829703f876897c9471a857e43d847b8799c3c9e2fbce644724b50aa4"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-win32.whl", hash = "sha256:84d0ff869f98be2e93efdf1ae31e5a15f0926d22af8677d51676e373abbfe57a"},
+    {file = "pydantic_core-2.41.1-cp39-cp39-win_amd64.whl", hash = "sha256:b5674314987cdde5a5511b029fa5fb1556b3d147a367e01dd583b19cfa8e35df"},
+    {file = "pydantic_core-2.41.1-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:68f2251559b8efa99041bb63571ec7cdd2d715ba74cc82b3bc9eff824ebc8bf0"},
+    {file = "pydantic_core-2.41.1-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:c7bc140c596097cb53b30546ca257dbe3f19282283190b1b5142928e5d5d3a20"},
+    {file = "pydantic_core-2.41.1-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2896510fce8f4725ec518f8b9d7f015a00db249d2fd40788f442af303480063d"},
+    {file = "pydantic_core-2.41.1-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ced20e62cfa0f496ba68fa5d6c7ee71114ea67e2a5da3114d6450d7f4683572a"},
+    {file = "pydantic_core-2.41.1-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b04fa9ed049461a7398138c604b00550bc89e3e1151d84b81ad6dc93e39c4c06"},
+    {file = "pydantic_core-2.41.1-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b3b7d9cfbfdc43c80a16638c6dc2768e3956e73031fca64e8e1a3ae744d1faeb"},
+    {file = "pydantic_core-2.41.1-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eec83fc6abef04c7f9bec616e2d76ee9a6a4ae2a359b10c21d0f680e24a247ca"},
+    {file = "pydantic_core-2.41.1-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6771a2d9f83c4038dfad5970a3eef215940682b2175e32bcc817bdc639019b28"},
+    {file = "pydantic_core-2.41.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:fabcbdb12de6eada8d6e9a759097adb3c15440fafc675b3e94ae5c9cb8d678a0"},
+    {file = "pydantic_core-2.41.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:80e97ccfaf0aaf67d55de5085b0ed0d994f57747d9d03f2de5cc9847ca737b08"},
+    {file = "pydantic_core-2.41.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34df1fe8fea5d332484a763702e8b6a54048a9d4fe6ccf41e34a128238e01f52"},
+    {file = "pydantic_core-2.41.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:421b5595f845842fc093f7250e24ee395f54ca62d494fdde96f43ecf9228ae01"},
+    {file = "pydantic_core-2.41.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:dce8b22663c134583aaad24827863306a933f576c79da450be3984924e2031d1"},
+    {file = "pydantic_core-2.41.1-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:300a9c162fea9906cc5c103893ca2602afd84f0ec90d3be36f4cc360125d22e1"},
+    {file = "pydantic_core-2.41.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e019167628f6e6161ae7ab9fb70f6d076a0bf0d55aa9b20833f86a320c70dd65"},
+    {file = "pydantic_core-2.41.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:13ab9cc2de6f9d4ab645a050ae5aee61a2424ac4d3a16ba23d4c2027705e0301"},
+    {file = "pydantic_core-2.41.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:af2385d3f98243fb733862f806c5bb9122e5fba05b373e3af40e3c82d711cef1"},
+    {file = "pydantic_core-2.41.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:6550617a0c2115be56f90c31a5370261d8ce9dbf051c3ed53b51172dd34da696"},
+    {file = "pydantic_core-2.41.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc17b6ecf4983d298686014c92ebc955a9f9baf9f57dad4065e7906e7bee6222"},
+    {file = "pydantic_core-2.41.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:42ae9352cf211f08b04ea110563d6b1e415878eea5b4c70f6bdb17dca3b932d2"},
+    {file = "pydantic_core-2.41.1-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e82947de92068b0a21681a13dd2102387197092fbe7defcfb8453e0913866506"},
+    {file = "pydantic_core-2.41.1-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:e244c37d5471c9acdcd282890c6c4c83747b77238bfa19429b8473586c907656"},
+    {file = "pydantic_core-2.41.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:1e798b4b304a995110d41ec93653e57975620ccb2842ba9420037985e7d7284e"},
+    {file = "pydantic_core-2.41.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f1fc716c0eb1663c59699b024428ad5ec2bcc6b928527b8fe28de6cb89f47efb"},
+    {file = "pydantic_core-2.41.1.tar.gz", hash = "sha256:1ad375859a6d8c356b7704ec0f547a58e82ee80bb41baa811ad710e124bc8f2f"},
 ]
 
 [package.dependencies]
-typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pygments"
@@ -796,66 +982,108 @@ files = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0.2"
+version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
-    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
-    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
-    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
-    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
-    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
-    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
-    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
-    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
-    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
-    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
-    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
-    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
-    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
-    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
-    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
-    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
-    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
-    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
-    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
-    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
-    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
-    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
-    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
-    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
-    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
-    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
-    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
-    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
-    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
-    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
-    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
-    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
-    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
-    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
+    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
+    {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
 ]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+description = "Python HTTP for Humans."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
+    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
+]
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset_normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<3"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "six"
@@ -898,14 +1126,14 @@ files = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51"},
-    {file = "typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28"},
+    {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
+    {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
 ]
 
 [package.dependencies]
@@ -960,15 +1188,33 @@ doc = ["python-docs-theme", "sphinx", "sphinx-copybutton"]
 test = ["pytest", "pytest_codspeed", "pytest_cov", "scipy"]
 
 [[package]]
+name = "urllib3"
+version = "2.5.0"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+]
+
+[package.extras]
+brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+h2 = ["h2 (>=4,<5)"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
 name = "xarray"
-version = "2025.9.0"
+version = "2025.10.1"
 description = "N-D labeled arrays and datasets in Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "xarray-2025.9.0-py3-none-any.whl", hash = "sha256:79f0e25fb39571f612526ee998ee5404d8725a1db3951aabffdb287388885df0"},
-    {file = "xarray-2025.9.0.tar.gz", hash = "sha256:7dd6816fe0062c49c5e9370dd483843bc13e5ed80a47a9ff10baff2b51e070fb"},
+    {file = "xarray-2025.10.1-py3-none-any.whl", hash = "sha256:a4e699433b87a7fac340951bc36648645eeef72bdd915ff055ac2fd99865a73d"},
+    {file = "xarray-2025.10.1.tar.gz", hash = "sha256:3c2b5ad7389825bd624ada5ff26b01ac54b1aae72e2fe0d724d81d40a2bf5785"},
 ]
 
 [package.dependencies]
@@ -977,24 +1223,24 @@ packaging = ">=24.1"
 pandas = ">=2.2"
 
 [package.extras]
-accel = ["bottleneck", "flox (>=0.9)", "numba (>=0.59)", "numbagg (>=0.8)", "numpy (<2.3)", "opt_einsum", "scipy (>=1.13)"]
+accel = ["bottleneck", "flox (>=0.9)", "numba (>=0.62)", "numbagg (>=0.8)", "opt_einsum", "scipy (>=1.13)"]
 complete = ["xarray[accel,etc,io,parallel,viz]"]
 etc = ["sparse (>=0.15)"]
 io = ["cftime", "fsspec", "h5netcdf", "netCDF4 (>=1.6.0)", "pooch", "pydap", "scipy (>=1.13)", "zarr (>=2.18)"]
 parallel = ["dask[complete]"]
-types = ["pandas-stubs", "scipy-stubs", "types-PyYAML", "types-Pygments", "types-colorama", "types-decorator", "types-defusedxml", "types-docutils", "types-networkx", "types-openpyxl", "types-pexpect", "types-psutil", "types-pycurl", "types-python-dateutil", "types-pytz", "types-setuptools"]
+types = ["pandas-stubs", "scipy-stubs", "types-PyYAML", "types-Pygments", "types-colorama", "types-decorator", "types-defusedxml", "types-docutils", "types-networkx", "types-openpyxl", "types-pexpect", "types-psutil", "types-pycurl", "types-python-dateutil", "types-pytz", "types-requests", "types-setuptools"]
 viz = ["cartopy (>=0.23)", "matplotlib", "nc-time-axis", "seaborn"]
 
 [[package]]
 name = "yadg"
-version = "6.2.1"
+version = "6.2.2"
 description = "yet another datagram"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "yadg-6.2.1-py3-none-any.whl", hash = "sha256:687accaf188c8b00b784ae0f8595736ccfb49281f2635a67ba2ab3cd6738a449"},
-    {file = "yadg-6.2.1.tar.gz", hash = "sha256:4b0fd9354fbe2c6a4cf57d251e29f295b057bd229023e4236ebc2a0fa06620dc"},
+    {file = "yadg-6.2.2-py3-none-any.whl", hash = "sha256:d319942fea0c43331a3a30e2e99f4874962ebd60ce166253bdeaa4a8931012c0"},
+    {file = "yadg-6.2.2.tar.gz", hash = "sha256:23a25163fe9d8994b75d302102e44beae571c20ace62258431cd6a8e60bc3b94"},
 ]
 
 [package.dependencies]
@@ -1023,5 +1269,5 @@ dev = ["pdoc", "pytest"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.13"
-content-hash = "d043764da31236b5f620121b114e9b8a391aa7320800fe1dceabff4154de44ed"
+python-versions = ">=3.12,<4.0"
+content-hash = "50d9f3653faa3db02223085649c318eee2342b38af9dfbb23960b77fc07b4c77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}
-requires-python = ">=3.13"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "pandas (>=2.3.2,<3.0.0)",
     "xarray (>=2025.9.0,<2026.0.0)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "xarray (>=2025.9.0,<2026.0.0)",
     "yadg (>=6.2.1,<7.0.0)",
     "pycodata (>=2.2.0,<3.0.0)",
+    "mermaid-py (>=0.8.0,<0.9.0)",
 ]
 
 [project.optional-dependencies]

--- a/src/echem_data_tool/file/__init__.py
+++ b/src/echem_data_tool/file/__init__.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2025 Friedrich-Schiller-Universität Jena, HIPOLE Jena
+# Authors: Christian Stolze, Sebastian Witt, Felix Nagler
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+File handling module for electrochemical netCDF data.
+
+This module provides object-oriented classes for working with hierarchical
+netCDF files containing electrochemical data and metadata.
+
+Main components:
+- FileObject: Complete file abstraction with data and metadata
+- Metadata classes: StudyMetadata, CellMetadata, TechniqueMetadata, AuxiliaryMetadata
+
+Example:
+    ```python
+    from echem_data_tool.file import FileObject
+    
+    # Create new file
+    file_obj = FileObject()
+    
+    # Set study metadata
+    file_obj.metadata.id = "test_study"
+    file_obj.metadata.description = "Example electrochemical study"
+    
+    # Add cell with metadata
+    cell = file_obj.add_cell("cell_001")
+    cell.metadata.id = "Cell-001"
+    cell.metadata.type = "coin"
+    cell.metadata.cathode = "LFP"
+    cell.metadata.anode = "Li"
+    cell.metadata.electrolyte = "LiPF6"
+    
+    # Add technique to cell
+    cv_technique = cell.add_technique("technique_001_CV")
+    cv_technique.metadata.type = "Cyclic Voltammetry"
+    cv_technique.data.add_variable("time", [0, 1, 2], {"units": "s"})
+    cv_technique.data.add_variable("potential", [0.1, 0.2, 0.3], {"units": "V"})
+    
+    # Save to file
+    file_obj.save("experiment.nc")
+    ```
+"""
+
+from .file import (
+    FileObject,
+    Cell,
+    Technique,
+    Auxiliary,
+    Group
+)
+
+from .data import (
+    DataGroup,
+    DataVariable
+)
+
+from .metadata import (
+    StudyMetadata,
+    CellMetadata,
+    TechniqueMetadata,
+    AuxiliaryMetadata,
+    GroupMetadata,
+    Contributor,
+    Funding,
+    SoftwareObject,
+    Device,
+    Parameter,
+    AmountObject,
+    Material,
+    CellComponent,
+    ChemistryObject,
+    AssemblyObject,
+    AdditionalNote,
+    BaseMetadata
+)
+
+__all__ = [
+    # File handling classes
+    "FileObject",
+    "Cell",
+    "Technique", 
+    "Auxiliary",
+    "Group",
+    "DataGroup",
+    "DataVariable",
+    
+    # Metadata classes
+    "StudyMetadata",
+    "CellMetadata", 
+    "TechniqueMetadata",
+    "AuxiliaryMetadata",
+    "GroupMetadata",
+    
+    # Helper classes
+    "Contributor",
+    "Funding",
+    "SoftwareObject",
+    "Device", 
+    "Parameter",
+    "AmountObject",
+    "Material",
+    "CellComponent",
+    "ChemistryObject",
+    "AssemblyObject", 
+    "AdditionalNote",
+    "BaseMetadata"
+]

--- a/src/echem_data_tool/file/data.py
+++ b/src/echem_data_tool/file/data.py
@@ -1,0 +1,170 @@
+# Copyright (C) 2025 Friedrich-Schiller-Universität Jena, HIPOLE Jena
+# Authors: Christian Stolze, Sebastian Witt, Felix Nagler
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Data handling classes for electrochemical data.
+
+This module provides classes for managing data variables and data groups
+that correspond to the 'data' subgroups within technique and auxiliary groups
+in the netCDF file structure.
+
+The module provides a clean abstraction for:
+- DataVariable: Individual data arrays with metadata
+- DataGroup: Collections of data variables (netCDF groups)
+
+Example:
+    ```python
+    from echem_data_tool.file.data import DataVariable, DataGroup
+    
+    # Create data group for a technique
+    data_group = DataGroup()
+    
+    # Add variables with metadata
+    data_group.add_variable("time", [0, 1, 2, 3], {"units": "s"})
+    data_group.add_variable("potential", [0.1, 0.2, 0.3, 0.4], {"units": "V"})
+    data_group.add_variable("current", [0.01, 0.02, 0.01, 0.0], {"units": "A"})
+    
+    # Access variables
+    time_data = data_group.get_variable("time")
+    print(f"Time units: {time_data.attributes['units']}")
+    
+    # Convert to xarray for analysis
+    dataset = data_group.to_xarray_dataset()
+    ```
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import xarray as xr
+
+
+@dataclass
+class DataVariable:
+    """Represents a data variable with its values and attributes.
+    
+    This corresponds to individual data arrays within netCDF data groups,
+    providing a clean interface for managing measurement data with metadata.
+    
+    Attributes:
+        name: Variable name (e.g., "time", "potential", "current")
+        data: Variable data (array-like)
+        attributes: Variable attributes (units, description, etc.)
+        dimensions: Dimension names for the variable
+    """
+    name: str
+    data: Union[List, np.ndarray]
+    attributes: Dict[str, Any] = field(default_factory=dict)
+    dimensions: List[str] = field(default_factory=lambda: ["time"])
+    
+    def to_xarray_variable(self) -> xr.DataArray:
+        """Convert to xarray DataArray for analysis and file I/O."""
+        return xr.DataArray(
+            data=self.data,
+            dims=self.dimensions,
+            attrs=self.attributes,
+            name=self.name
+        )
+
+
+@dataclass
+class DataGroup:
+    """Represents a data group containing multiple data variables.
+    
+    This corresponds to the 'data' subgroup within technique and auxiliary groups
+    in the netCDF structure. It provides methods for managing collections of
+    related data variables with group-level metadata.
+    
+    Attributes:
+        variables: Dictionary of data variables {name: DataVariable}
+        attributes: Group-level attributes
+    """
+    variables: Dict[str, DataVariable] = field(default_factory=dict)
+    attributes: Dict[str, Any] = field(default_factory=dict)
+    
+    def add_variable(self, name: str, data: Union[List, np.ndarray], 
+                    attributes: Optional[Dict[str, Any]] = None,
+                    dimensions: Optional[List[str]] = None) -> DataVariable:
+        """Add a data variable to this group.
+        
+        Args:
+            name: Variable name
+            data: Variable data (array-like)
+            attributes: Variable attributes (units, description, etc.)
+            dimensions: Dimension names (defaults to ["time"])
+            
+        Returns:
+            The created DataVariable
+        """
+        if dimensions is None:
+            dimensions = ["time"]
+        
+        var = DataVariable(
+            name=name,
+            data=data,
+            attributes=attributes or {},
+            dimensions=dimensions
+        )
+        self.variables[name] = var
+        return var
+    
+    def get_variable(self, name: str) -> Optional[DataVariable]:
+        """Get a data variable by name.
+        
+        Args:
+            name: Variable name
+            
+        Returns:
+            DataVariable if found, None otherwise
+        """
+        return self.variables.get(name)
+    
+    def remove_variable(self, name: str) -> bool:
+        """Remove a data variable.
+        
+        Args:
+            name: Variable name
+            
+        Returns:
+            True if found and removed, False otherwise
+        """
+        if name in self.variables:
+            del self.variables[name]
+            return True
+        return False
+    
+    def list_variables(self) -> List[str]:
+        """List all variable names in this data group.
+        
+        Returns:
+            List of variable names
+        """
+        return list(self.variables.keys())
+    
+    def to_xarray_dataset(self) -> xr.Dataset:
+        """Convert to xarray Dataset for analysis and file I/O.
+        
+        Returns:
+            xarray Dataset with all variables and group attributes
+        """
+        data_vars = {
+            name: var.to_xarray_variable() 
+            for name, var in self.variables.items()
+        }
+        return xr.Dataset(data_vars=data_vars, attrs=self.attributes)

--- a/src/echem_data_tool/file/file.py
+++ b/src/echem_data_tool/file/file.py
@@ -1,0 +1,1192 @@
+# Copyright (C) 2025 Friedrich-Schiller-Universität Jena, HIPOLE Jena
+# Authors: Christian Stolze, Sebastian Witt, Felix Nagler
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+NetCDF file handling module for electrochemical data.
+
+This module provides object-oriented classes for handling the hierarchical
+netCDF file structure according to the file format specification defined
+in design-docs/file_format_specs.md.
+
+The module provides a complete abstraction of xarray/netCDF operations through
+a FileObject class that mirrors the hierarchical structure:
+
+Study (Root)
+├── Metadata (study-level)
+├── Cells/
+│   ├── Cell 1
+│   │   ├── Metadata (cell-level)
+│   │   ├── Groups/
+│   │   │   ├── Group 1
+│   │   │   │   ├── Technique 1 (with data variables)
+│   │   │   │   ├── Technique 2
+│   │   │   │   └── Auxiliary 1 (with data variables)
+│   │   │   └── Group 2
+│   │   │       ├── Technique 3
+│   │   │       └── Auxiliary 2
+│   │   ├── Ungrouped Techniques...
+│   │   └── Ungrouped Auxiliaries...
+│   └── Cell 2
+│       ├── Metadata
+│       ├── Groups...
+│       └── [Techniques/Auxiliaries]
+└── [Future Extensions]
+
+Example:
+    ```python
+    from echem_data_tool.file import FileObject
+    
+    # Create new file structure
+    file_obj = FileObject()
+    
+    # Set study metadata
+    file_obj.metadata.id = "polymer_zn_battery_study"
+    file_obj.metadata.description = "Polymer electrolyte zinc battery characterization"
+    file_obj.metadata.add_contributor("Jane Doe", "jane@uni.edu", "University Lab")
+    
+    # Add cell with metadata
+    cell = file_obj.add_cell("cell_001")
+    cell.metadata.id = "Cell-001"
+    cell.metadata.type = "Polymer Zn battery"
+    cell.metadata.cathode = "MnO2"
+    cell.metadata.anode = "Zn"
+    cell.metadata.electrolyte = "PEO-LiTFSI"
+    
+    # Create groups for organized measurements
+    characterization_group = cell.add_group("characterization")
+    cycling_group = cell.add_group("cycling")
+    
+    # Add techniques
+    cv_technique = cell.add_technique("technique_001_CV")
+    cv_technique.metadata.type = "Cyclic Voltammetry"
+    cv_technique.metadata.id = 1
+    cv_technique.data.add_variable("time", [0, 1, 2, 3], {"units": "s"})
+    cv_technique.data.add_variable("potential", [0.1, 0.2, 0.3, 0.4], {"units": "V"})
+    cv_technique.data.add_variable("current", [0.01, 0.02, 0.01, 0.0], {"units": "A"})
+    
+    charge_technique = cell.add_technique("technique_002_charge")
+    charge_technique.metadata.type = "Galvanostatic Charge"
+    charge_technique.metadata.id = 2
+    
+    # Add auxiliary measurement
+    temp_aux = cell.add_auxiliary("auxiliary_001_temperature")
+    temp_aux.metadata.type = "Temperature"
+    temp_aux.metadata.id = 1
+    temp_aux.data.add_variable("time", [0, 1, 2, 3], {"units": "s"})
+    temp_aux.data.add_variable("temperature", [25.1, 25.2, 25.3, 25.4], {"units": "°C"})
+    
+    # Organize techniques and auxiliaries in groups
+    characterization_group.add_technique(cv_technique)
+    characterization_group.add_auxiliary(temp_aux)
+    cycling_group.add_technique(charge_technique)
+    
+    # Print internal file architecture
+    file_obj.print_structure()
+    
+    # Save to netCDF
+    file_obj.save("polymer_zn_battery.nc")
+    
+    # Load from netCDF
+    loaded_file = FileObject.load("polymer_zn_battery.nc")
+    ```
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import xarray as xr
+
+from .metadata import StudyMetadata, CellMetadata, TechniqueMetadata, AuxiliaryMetadata, GroupMetadata
+from .data import DataVariable, DataGroup
+
+
+# =============================================================================
+# HIERARCHICAL CLASSES  
+# =============================================================================
+
+class Technique:
+    """Represents a technique with metadata and data.
+    
+    Corresponds to technique_XXX_YYYY groups in the netCDF structure.
+    
+    The technique provides two main properties:
+    - .metadata: Access to technique metadata (TechniqueMetadata)
+    - .data: Access to data variables (DataGroup)
+    """
+    
+    def __init__(self, name: str, cell: Optional['Cell'] = None):
+        self.name = name
+        self.metadata = TechniqueMetadata()
+        self._data = DataGroup()
+
+    @property
+    def data(self) -> DataGroup:
+        """Access to the data group containing all data variables."""
+        return self._data
+    
+    def to_xarray_group(self) -> xr.Dataset:
+        """Convert to xarray Dataset for this technique."""
+        # Create the data subgroup
+        data_ds = self._data.to_xarray_dataset()
+        
+        # For now, we'll flatten the structure since xarray groups are complex
+        # The metadata will be stored as attributes on the main dataset
+        data_ds.attrs.update(self.metadata.to_netcdf_attrs())
+        
+        return data_ds
+
+
+class Auxiliary:
+    """Represents auxiliary data with metadata and data.
+    
+    Corresponds to auxiliary_XXX_YYYY groups in the netCDF structure.
+    
+    The auxiliary provides two main properties:
+    - .metadata: Access to auxiliary metadata (AuxiliaryMetadata)
+    - .data: Access to data variables (DataGroup)
+    """
+    
+    def __init__(self, name: str, cell: Optional['Cell'] = None):
+        self.name = name
+        self.metadata = AuxiliaryMetadata()
+        self._data = DataGroup()
+    
+    @property
+    def data(self) -> DataGroup:
+        """Access to the data group containing all data variables."""
+        return self._data
+    
+    def to_xarray_group(self) -> xr.Dataset:
+        """Convert to xarray Dataset for this auxiliary."""
+        # Create the data subgroup
+        data_ds = self._data.to_xarray_dataset()
+        
+        # Add metadata as attributes
+        data_ds.attrs.update(self.metadata.to_netcdf_attrs())
+        
+        return data_ds
+
+class Group:
+    """Represents a technique/auxiliary group with metadata and member management.
+    
+    Groups are organizational units that contain related techniques and/or 
+    auxiliary measurements. They provide:
+    - Group-specific metadata
+    - Methods to add/remove techniques and auxiliaries
+    - Access to all group members
+    
+    Example:
+        ```python
+        cv_group = cell.add_group("CV_Analysis")
+        cv_group.metadata.description = "Rate capability study"
+        cv_technique = cv_group.add_technique("technique_001_CV")
+        ```
+    """
+    
+    def __init__(self, id: int, name: str, cell: Optional['Cell'] = None):
+        """Initialize group.
+        
+        Args:
+            id: Unique group ID within the cell
+            name: Group name
+            cell: Reference to parent CellGroup
+        """
+        self.id = id
+        self.name = name
+        self.metadata = GroupMetadata(id=id, name=name)
+        
+        # Group members
+        self.techniques: Dict[str, 'Technique'] = {}
+        self.auxiliary: Dict[str, 'Auxiliary'] = {}
+    
+    def add_technique(self, technique: Union['Technique', List['Technique']]) -> None:
+        """Add technique(s) to this group.
+        
+        Args:
+            technique: Technique object or list of Technique objects to add to this group
+        """
+        # Handle single technique
+        if not isinstance(technique, list):
+            # Set group references in metadata
+            technique.metadata.group_id = self.id
+            technique.metadata.group_name = self.name
+            self.techniques[technique.name] = technique
+            return
+        
+        # Handle list of techniques
+        for tech in technique:
+            # Set group references in metadata
+            tech.metadata.group_id = self.id
+            tech.metadata.group_name = self.name
+            self.techniques[tech.name] = tech
+    
+    def add_auxiliary(self, auxiliary: Union['Auxiliary', List['Auxiliary']]) -> None:
+        """Add auxiliary data to this group.
+        
+        Args:
+            auxiliary: Auxiliary object or list of Auxiliary objects to add to this group
+        """
+        # Handle single auxiliary
+        if not isinstance(auxiliary, list):
+            # Set group references in metadata
+            auxiliary.metadata.group_id = self.id
+            auxiliary.metadata.group_name = self.name
+            self.auxiliary[auxiliary.name] = auxiliary
+            return
+        
+        # Handle list of auxiliaries
+        for aux in auxiliary:
+            # Set group references in metadata
+            aux.metadata.group_id = self.id
+            aux.metadata.group_name = self.name
+            self.auxiliary[aux.name] = aux
+    
+    def remove_technique(self, technique: Union['Technique', List['Technique']]) -> Union[bool, List[bool]]:
+        """Remove technique(s) from this group.
+        
+        Args:
+            technique: Technique object or list of Technique objects to remove
+            
+        Returns:
+            True/False if single technique was found and removed, or list of True/False for each technique
+        """
+        # Handle single technique
+        if not isinstance(technique, list):
+            if technique.name in self.techniques and self.techniques[technique.name] is technique:
+                # Clear group references in metadata
+                technique.metadata.group_id = None
+                technique.metadata.group_name = None
+                del self.techniques[technique.name]
+                return True
+            return False
+        
+        # Handle list of techniques
+        results = []
+        for tech in technique:
+            if tech.name in self.techniques and self.techniques[tech.name] is tech:
+                # Clear group references in metadata
+                tech.metadata.group_id = None
+                tech.metadata.group_name = None
+                del self.techniques[tech.name]
+                results.append(True)
+            else:
+                results.append(False)
+        
+        return results
+    
+    def remove_auxiliary(self, auxiliary: Union['Auxiliary', List['Auxiliary']]) -> Union[bool, List[bool]]:
+        """Remove auxiliary data from this group.
+        
+        Args:
+            auxiliary: Auxiliary object or list of Auxiliary objects to remove
+            
+        Returns:
+            True/False if single auxiliary was found and removed, or list of True/False for each auxiliary
+        """
+        # Handle single auxiliary
+        if not isinstance(auxiliary, list):
+            if auxiliary.name in self.auxiliary and self.auxiliary[auxiliary.name] is auxiliary:
+                # Clear group references in metadata
+                auxiliary.metadata.group_id = None
+                auxiliary.metadata.group_name = None
+                del self.auxiliary[auxiliary.name]
+                return True
+            return False
+        
+        # Handle list of auxiliaries
+        results = []
+        for aux in auxiliary:
+            if aux.name in self.auxiliary and self.auxiliary[aux.name] is aux:
+                # Clear group references in metadata
+                aux.metadata.group_id = None
+                aux.metadata.group_name = None
+                del self.auxiliary[aux.name]
+                results.append(True)
+            else:
+                results.append(False)
+        
+        return results
+    
+    def list_techniques(self) -> List[str]:
+        """List all technique names in this group."""
+        return list(self.techniques.keys())
+    
+    def list_auxiliary(self) -> List[str]:
+        """List all auxiliary names in this group."""
+        return list(self.auxiliary.keys())
+    
+    def list_all(self) -> Dict[str, Union['Technique', 'Auxiliary']]:
+        """Get all group members (techniques + auxiliaries)."""
+        members = {}
+        members.update(self.techniques)
+        members.update(self.auxiliary)
+        return members
+    
+    def count_all(self) -> int:
+        """Get total number of members in this group."""
+        return len(self.techniques) + len(self.auxiliary)
+    
+    def is_empty(self) -> bool:
+        """Check if group has no members."""
+        return self.count_all() == 0
+
+
+class Cell:
+    """Represents a cell with metadata, techniques, and auxiliary data.
+    
+    Corresponds to cell_XXX groups in the netCDF structure.
+    """
+    
+    def __init__(self, name: str):
+        self.name = name
+        self.metadata = CellMetadata()
+        self.groups: Dict[str, Group] = {}
+        self.techniques: Dict[str, Technique] = {}
+        self.auxiliary: Dict[str, Auxiliary] = {}
+    
+    def add_technique(self, name: str, overwrite: bool = False) -> Technique:
+        """Add a technique to this cell.
+    
+        Args:
+            name: Technique name (e.g., "technique_001_CV")
+            overwrite: If False (default), raises ValueError if technique already exists.
+                      If True, overwrites existing technique.
+    
+        Returns:
+            The created Technique
+    
+        Raises:
+            ValueError: If technique with same name already exists and overwrite=False
+        """
+        if self.has_technique(name) and not overwrite:
+            raise ValueError(f"Technique '{name}' already exists. Use overwrite=True to replace it.")
+        
+        technique = Technique(name, cell=self)
+        self.techniques[name] = technique
+        return technique
+    
+    def get_technique(self, name: str) -> Optional[Technique]:
+        """Get a technique by name."""
+        return self.techniques.get(name)
+    
+    def get_technique_by_id(self, technique_id: int) -> Optional[Technique]:
+        """Get a technique by its metadata ID."""
+        for technique in self.techniques.values():
+            if technique.metadata.id == technique_id:
+                return technique
+        return None
+    
+    def remove_technique(self, name: str) -> bool:
+        """Remove a technique. Returns True if found and removed."""
+        if name in self.techniques:
+            del self.techniques[name]
+            return True
+        return False
+    
+    def list_techniques(self) -> List[str]:
+        """List all technique names."""
+        return list(self.techniques.keys())
+    
+    def add_auxiliary(self, name: str, overwrite: bool = False) -> Auxiliary:
+        """Add auxiliary data to this cell.
+        
+        Args:
+            name: Auxiliary name (e.g., "auxiliary_001_temperature")
+            overwrite: If False (default), raises ValueError if auxiliary already exists.
+                      If True, overwrites existing auxiliary.
+        
+        Returns:
+            The created Auxiliary
+            
+        Raises:
+            ValueError: If auxiliary with same name already exists and overwrite=False
+        """
+        if self.has_auxiliary(name) and not overwrite:
+            raise ValueError(f"Auxiliary '{name}' already exists. Use overwrite=True to replace it.")
+        
+        auxiliary = Auxiliary(name, cell=self)
+        self.auxiliary[name] = auxiliary
+        return auxiliary
+    
+    def get_auxiliary(self, name: str) -> Optional[Auxiliary]:
+        """Get auxiliary data by name."""
+        return self.auxiliary.get(name)
+    
+    def get_auxiliary_by_id(self, auxiliary_id: int) -> Optional[Auxiliary]:
+        """Get auxiliary data by its metadata ID."""
+        for aux in self.auxiliary.values():
+            if aux.metadata.id == auxiliary_id:
+                return aux
+        return None
+    
+    def remove_auxiliary(self, name: str) -> bool:
+        """Remove auxiliary data. Returns True if found and removed."""
+        if name in self.auxiliary:
+            del self.auxiliary[name]
+            return True
+        return False
+    
+    def list_auxiliary(self) -> List[str]:
+        """List all auxiliary data names."""
+        return list(self.auxiliary.keys())
+    
+    def has_technique(self, name: str) -> bool:
+        """Check if a technique with the given name exists."""
+        return name in self.techniques
+    
+    def has_auxiliary(self, name: str) -> bool:
+        """Check if auxiliary data with the given name exists."""
+        return name in self.auxiliary
+    
+    # -------------------------------------------------------------------------
+    # GROUP MANAGEMENT OPERATIONS
+    # -------------------------------------------------------------------------
+    
+    def add_group(self, name: str, id: Optional[int] = None, overwrite: bool = False) -> Group:
+        """Add a group to this cell.
+        
+        Args:
+            name: Group name
+            id: Optional group ID (auto-generated if not provided)
+            overwrite: If False (default), raises ValueError if group already exists.
+                      If True, overwrites existing group.
+        
+        Returns:
+            The created Group
+        
+        Raises:
+            ValueError: If group already exists and overwrite=False
+        """
+        if name in self.groups and not overwrite:
+            raise ValueError(f"Group '{name}' already exists. Use overwrite=True to replace it.")
+        
+        # Auto-generate ID if not provided
+        if id is None:
+            existing_ids = [group.id for group in self.groups.values()]
+            id = 1
+            while id in existing_ids:
+                id += 1
+        
+        # Check for ID conflicts
+        for existing_group in self.groups.values():
+            if existing_group.id == id and existing_group.name != name and not overwrite:
+                raise ValueError(f"Group ID {id} is already used by group '{existing_group.name}'")
+        
+        group = Group(id=id, name=name, cell=self)
+        self.groups[name] = group
+        return group
+    
+    def get_group(self, name: str) -> Optional[Group]:
+        """Get a group by name."""
+        return self.groups.get(name)
+    
+    def get_group_by_id(self, id: int) -> Optional[Group]:
+        """Get a group by ID."""
+        for group in self.groups.values():
+            if group.id == id:
+                return group
+        return None
+    
+    def remove_group(self, name: str) -> bool:
+        """Remove a group by name. Returns True if found and removed.
+        
+        Note: This will also remove all techniques/auxiliaries from the group.
+        """
+        if name in self.groups:
+            group = self.groups[name]
+            
+            # Clear group references from all members when group is removed
+            for technique in group.techniques.values():
+                technique.metadata.group_id = None
+                technique.metadata.group_name = None
+            
+            for auxiliary in group.auxiliary.values():
+                auxiliary.metadata.group_id = None
+                auxiliary.metadata.group_name = None
+            
+            del self.groups[name]
+            return True
+        return False
+    
+    def list_groups(self) -> Dict[str, Group]:
+        """List all groups as {group_name: Group} mapping."""
+        return self.groups.copy()
+    
+    def has_group(self, name: str) -> bool:
+        """Check if a group with the given name exists."""
+        return name in self.groups
+    
+    def has_group_id(self, id: int) -> bool:
+        """Check if a group with the given ID exists."""
+        return any(group.id == id for group in self.groups.values())
+    
+    def get_group_name_by_id(self, id: int) -> Optional[str]:
+        """Get group name by ID (for backward compatibility)."""
+        group = self.get_group_by_id(id)
+        return group.name if group else None
+
+
+# =============================================================================
+# MAIN FILE OBJECT CLASS
+# =============================================================================
+
+class FileObject:
+    """Object-oriented representation of the hierarchical netCDF file structure.
+    
+    This class provides complete abstraction of xarray/netCDF operations and
+    mirrors the file format specification structure with:
+
+    - Study-level metadata
+    - Cells with metadata
+    - Techniques with data
+    - Auxiliary data with data
+    
+    The class handles all xarray complexity internally and provides a clean,
+    intuitive API for working with electrochemical data files.
+    """
+    
+    def __init__(self):
+        """Initialize empty file object."""
+
+        # study-level metadata - automatically created
+        self.study_metadata: StudyMetadata = StudyMetadata()
+
+        # study-level groups
+        self.cells: Dict[str, Cell] = {}
+        # self.future_extensions: Dict[str, FutureExtensionGroup] = {} # Placeholder for future extensions
+    
+    @property
+    def metadata(self) -> StudyMetadata:
+        """Access to study-level metadata."""
+        return self.study_metadata
+    
+    # -------------------------------------------------------------------------
+    # CELL-LEVEL OPERATIONS
+    # -------------------------------------------------------------------------
+    
+    def add_cell(self, name: str, overwrite: bool = False) -> Cell:
+        """Add a cell to the study.
+        
+        Args:
+            name: Cell name (e.g., "cell_001")
+            overwrite: If False (default), raises ValueError if cell already exists.
+                      If True, overwrites existing cell.
+        
+        Returns:
+            The created Cell
+            
+        Raises:
+            ValueError: If cell with same name already exists and overwrite=False
+        """
+        if self.has_cell(name) and not overwrite:
+            raise ValueError(f"Cell '{name}' already exists. Use overwrite=True to replace it.")
+        
+        cell = Cell(name)
+        self.cells[name] = cell
+        return cell
+
+    def get_cell(self, name: str) -> Optional[Cell]:
+        """Get a cell by name."""
+        return self.cells.get(name)
+
+    def get_cell_by_id(self, cell_id: str) -> Optional[Cell]:
+        """Get a cell by its metadata ID."""
+        for cell in self.cells.values():
+            if cell.metadata.id == cell_id:
+                return cell
+        return None
+    
+    def remove_cell(self, name: str) -> bool:
+        """Remove a cell. Returns True if found and removed."""
+        if name in self.cells:
+            del self.cells[name]
+            return True
+        return False
+    
+    def list_cells(self) -> List[str]:
+        """List all cell names."""
+        return list(self.cells.keys())
+    
+    def has_cell(self, name: str) -> bool:
+        """Check if a cell with the given name exists."""
+        return name in self.cells
+    
+    # -------------------------------------------------------------------------
+    # FILE I/O OPERATIONS
+    # -------------------------------------------------------------------------
+    
+    def to_xarray_dataset(self) -> xr.Dataset:
+        """Convert file object to xarray Dataset.
+        
+        This flattens the hierarchical structure into a single dataset
+        with appropriate variable naming and metadata organization.
+        """
+        # Start with empty dataset
+        data_vars = {}
+        attrs = {}
+        
+        # Add study metadata as global attributes
+        attrs.update(self.study_metadata.to_netcdf_attrs())
+        
+        # Process each cell
+        for cell_name, cell in self.cells.items():
+            # Add cell metadata to global attributes with prefix
+            cell_attrs = cell.metadata.to_netcdf_attrs()
+            for attr_name, attr_value in cell_attrs.items():
+                attrs[f"{cell_name}_{attr_name}"] = attr_value
+            
+            # Process techniques
+            for technique_name, technique in cell.techniques.items():
+                # Add technique metadata to global attributes
+                tech_attrs = technique.metadata.to_netcdf_attrs()
+                tech_prefix = f"{cell_name}_{technique_name}"
+                for attr_name, attr_value in tech_attrs.items():
+                    attrs[f"{tech_prefix}_{attr_name}"] = attr_value
+                
+                # Add technique data variables
+                for var_name, var in technique.data.variables.items():
+                    full_var_name = f"{tech_prefix}_{var_name}"
+                    data_vars[full_var_name] = var.to_xarray_variable()
+            
+            # Process auxiliary data
+            for aux_name, aux in cell.auxiliary.items():
+                # Add auxiliary metadata to global attributes
+                aux_attrs = aux.metadata.to_netcdf_attrs()
+                aux_prefix = f"{cell_name}_{aux_name}"
+                for attr_name, attr_value in aux_attrs.items():
+                    attrs[f"{aux_prefix}_{attr_name}"] = attr_value
+                
+                # Add auxiliary data variables
+                for var_name, var in aux.data.variables.items():
+                    full_var_name = f"{aux_prefix}_{var_name}"
+                    data_vars[full_var_name] = var.to_xarray_variable()
+        
+        return xr.Dataset(data_vars=data_vars, attrs=attrs)
+    
+    def save(self, filename: Union[str, Path], engine: str = "h5netcdf") -> None:
+        """Save file object to netCDF file.
+        
+        Args:
+            filename: Output filename
+            engine: NetCDF engine to use ("h5netcdf" or "netcdf4")
+        """
+        ds = self.to_xarray_dataset()
+        ds.to_netcdf(filename, engine=engine)
+    
+    @classmethod
+    def load(cls, filename: Union[str, Path]) -> FileObject:
+        """Load file object from netCDF file.
+        
+        Args:
+            filename: Input filename
+            
+        Returns:
+            FileObject instance loaded from file
+        """
+        ds = xr.open_dataset(filename)
+        
+        file_obj = cls()
+        
+        # Extract study metadata from global attributes and update the automatically created instance
+        try:
+            if "study_metadata_json" in ds.attrs:
+                study_data = json.loads(ds.attrs["study_metadata_json"])
+                # Update the automatically created StudyMetadata instance
+                file_obj.study_metadata.id = study_data["study_metadata"]["id"]
+                file_obj.study_metadata.description = study_data["study_metadata"]["description"]
+                file_obj.study_metadata.format_version = study_data["file_metadata"]["format_version"]
+                file_obj.study_metadata.timestamp = datetime.fromisoformat(study_data["file_metadata"]["timestamp"])
+            else:
+                # Fallback to individual attributes - update the existing instance
+                loaded_metadata = StudyMetadata.from_netcdf_attrs(ds.attrs)
+                file_obj.study_metadata.id = loaded_metadata.id
+                file_obj.study_metadata.description = loaded_metadata.description
+                file_obj.study_metadata.format_version = loaded_metadata.format_version
+                file_obj.study_metadata.timestamp = loaded_metadata.timestamp
+        except (KeyError, json.JSONDecodeError, ValueError):
+            # If metadata extraction fails, set minimal values on existing instance
+            file_obj.study_metadata.id = "unknown"
+            file_obj.study_metadata.description = ""
+        
+        # Extract cell, technique, and auxiliary data
+        # This is complex and would require parsing the flattened attribute names
+        # For now, we'll implement a basic version
+        
+        # TODO: Implement full reconstruction of hierarchical structure
+        # This requires parsing attribute names like:
+        # - cell_001_cell_id, cell_001_cell_type, etc. for cell metadata
+        # - cell_001_technique_001_CV_technique_id, etc. for technique metadata
+        # - cell_001_auxiliary_001_temperature_auxiliary_id, etc. for auxiliary metadata
+        # And reconstructing data variables with prefixes like:
+        # - cell_001_technique_001_CV_time, cell_001_technique_001_CV_potential, etc.
+        
+        return file_obj
+    
+    # -------------------------------------------------------------------------
+    # UTILITY METHODS
+    # -------------------------------------------------------------------------
+    
+    def validate(self) -> List[str]:
+        """Validate file structure and return list of issues."""
+        issues = []
+        
+        if not self.study_metadata.id:
+            issues.append("Study metadata has no ID set")
+        
+        if not self.cells:
+            issues.append("No cells defined")
+        
+        for cell_name, cell in self.cells.items():
+            if not cell.metadata:
+                issues.append(f"Cell {cell_name} has no metadata")
+            
+            if not cell.techniques and not cell.auxiliary:
+                issues.append(f"Cell {cell_name} has no techniques or auxiliary data")
+            
+            # Check for technique ID conflicts
+            tech_ids = [tech.metadata.id for tech in cell.techniques.values()]
+            if len(tech_ids) != len(set(tech_ids)):
+                issues.append(f"Cell {cell_name} has duplicate technique IDs")
+            
+            # Check for auxiliary ID conflicts
+            aux_ids = [aux.metadata.id for aux in cell.auxiliary.values()]
+            if len(aux_ids) != len(set(aux_ids)):
+                issues.append(f"Cell {cell_name} has duplicate auxiliary IDs")
+        
+        return issues
+    
+    def print_structure(self, show_metadata: bool = True, show_data: bool = False) -> None:
+        """Print a visual tree structure of the file object to terminal.
+        
+        Args:
+            show_metadata: Whether to show metadata details
+            show_data: Whether to show data variable details
+        """
+        print("📁 FileObject Structure")
+        print("=" * 50)
+        
+        # Study level
+        print(f"🔬 Study: {self.study_metadata.id}")
+        if show_metadata:
+            print(f"   📝 Description: {self.study_metadata.description[:60]}{'...' if len(self.study_metadata.description) > 60 else ''}")
+            print(f"   📅 Created: {self.study_metadata.timestamp.strftime('%Y-%m-%d %H:%M')}")
+            print(f"   👥 Contributors: {len(self.study_metadata.contributors)}")
+            print(f"   💰 Funding: {len(self.study_metadata.funding)} sources")
+        
+        # Study subgroups level
+        study_subgroups = []
+        if self.cells:
+            study_subgroups.append(("cells", len(self.cells)))
+        # Future subgroups can be added here:
+        # if self.future_extensions:
+        #     study_subgroups.append(("extensions", len(self.future_extensions)))
+        
+        if not study_subgroups:
+            print("   └── (no subgroups)")
+            return
+        
+        for i, (subgroup_name, count) in enumerate(study_subgroups):
+            is_last_subgroup = (i == len(study_subgroups) - 1)
+            subgroup_connector = "└──" if is_last_subgroup else "├──"
+            subgroup_prefix = "   " if is_last_subgroup else "│  "
+            
+            print(f"   {subgroup_connector} 📂 {subgroup_name}/ ({count} items)")
+            
+            # Show cells as sub-items of the cells subgroup
+            if subgroup_name == "cells":
+                if not self.cells:
+                    print(f"   {subgroup_prefix}    └── (no cells)")
+                    continue
+                
+                # Cells level - now properly nested under cells/ subgroup
+                cell_names = list(self.cells.keys())
+                for j, (cell_name, cell) in enumerate(self.cells.items()):
+                    is_last_cell = (j == len(self.cells) - 1)
+                    cell_connector = "└──" if is_last_cell else "├──"
+                    cell_prefix = f"{subgroup_prefix}    {'   ' if is_last_cell else '│  '}"
+                    
+                    print(f"   {subgroup_prefix}    {cell_connector} 🔋 {cell_name}")
+                    if show_metadata:
+                        print(f"   {cell_prefix}    📋 ID: {cell.metadata.id}")
+                        print(f"   {cell_prefix}    🏷️  Type: {cell.metadata.type}")
+                        print(f"   {cell_prefix}    🧪 Chemistry: {cell.metadata.cathode} | {cell.metadata.electrolyte} | {cell.metadata.anode}")
+                        print(f"   {cell_prefix}    ⚙️  Components: {len(cell.metadata.components)}")
+                    
+                    # Group techniques and auxiliaries by their groups
+                    all_items = []
+                    for tech_name, tech in cell.techniques.items():
+                        all_items.append(("technique", tech_name, tech))
+                    for aux_name, aux in cell.auxiliary.items():
+                        all_items.append(("auxiliary", aux_name, aux))
+                    
+                    if not all_items:
+                        print(f"   {cell_prefix}    └── (no techniques or auxiliary)")
+                        continue
+                    
+                    # Organize items by groups using the new group management
+                    groups = {}
+                    ungrouped = []
+                    
+                    for item_type, item_name, item_obj in all_items:
+                        # Get group info from the object's metadata
+                        group_id = item_obj.metadata.group_id
+                        group_name = item_obj.metadata.group_name
+                        
+                        if group_id is not None and group_name is not None:
+                            # Verify group exists in cell's group registry
+                            cell_group = cell.get_group_by_id(group_id)
+                            if cell_group is not None:
+                                # Use the group from cell registry (authoritative source)
+                                group_key = f"{cell_group.name}_{group_id}"
+                                
+                                if group_key not in groups:
+                                    groups[group_key] = {
+                                        'name': cell_group.name,
+                                        'id': group_id,
+                                        'items': []
+                                    }
+                                groups[group_key]['items'].append((item_type, item_name, item_obj))
+                            else:
+                                # Group ID not found in registry, treat as ungrouped
+                                ungrouped.append((item_type, item_name, item_obj))
+                        else:
+                            ungrouped.append((item_type, item_name, item_obj))
+                    
+                    # Display grouped items first
+                    group_keys = list(groups.keys())
+                    total_groups = len(group_keys)
+                    has_ungrouped = len(ungrouped) > 0
+                    
+                    for g_idx, group_key in enumerate(group_keys):
+                        group_data = groups[group_key]
+                        is_last_group = (g_idx == total_groups - 1) and not has_ungrouped
+                        group_connector = "└──" if is_last_group else "├──"
+                        group_prefix = f"{cell_prefix}    {'   ' if is_last_group else '│  '}"
+                        
+                        # Display group header
+                        group_display = f"📁 Group: {group_data['name']}"
+                        if group_data['id'] is not None:
+                            group_display += f" (ID: {group_data['id']})"
+                        group_display += f" ({len(group_data['items'])} items)"
+                        
+                        print(f"   {cell_prefix}    {group_connector} {group_display}")
+                        
+                        # Display items within the group
+                        for item_idx, (item_type, item_name, item_obj) in enumerate(group_data['items']):
+                            is_last_item = (item_idx == len(group_data['items']) - 1)
+                            item_connector = "└──" if is_last_item else "├──"
+                            # Fixed prefix calculation for metadata indentation under grouped items
+                            metadata_prefix = f"{group_prefix}    {'   ' if is_last_item else '│  '}"
+                            
+                            icon = "📊" if item_type == "technique" else "🔍"
+                            print(f"   {group_prefix}    {item_connector} {icon} {item_name}")
+                            
+                            if show_metadata:
+                                print(f"   {metadata_prefix}    📋 ID: {item_obj.metadata.id}")
+                                print(f"   {metadata_prefix}    🏷️  Type: {item_obj.metadata.type}")
+                                if hasattr(item_obj.metadata, 'start') and item_obj.metadata.start:
+                                    duration = ""
+                                    if hasattr(item_obj.metadata, 'end') and item_obj.metadata.end:
+                                        duration = f" → {item_obj.metadata.end.strftime('%H:%M')}"
+                                    print(f"   {metadata_prefix}    📅 Time: {item_obj.metadata.start.strftime('%Y-%m-%d %H:%M')}{duration}")
+                                print(f"   {metadata_prefix}    🔧 Devices: {len(item_obj.metadata.devices)}")
+                                print(f"   {metadata_prefix}    ⚙️  Settings: {len(item_obj.metadata.settings)}")
+                            
+                            if show_data and item_obj.data.variables:
+                                data_vars = list(item_obj.data.variables.keys())
+                                print(f"   {metadata_prefix}    📊 Data vars: {', '.join(data_vars[:3])}{' ...' if len(data_vars) > 3 else ''}")
+                    
+                    # Display ungrouped items directly under cell
+                    if ungrouped:
+                        for item_idx, (item_type, item_name, item_obj) in enumerate(ungrouped):
+                            # Last ungrouped item is the last item overall (regardless of groups)
+                            is_last_item = (item_idx == len(ungrouped) - 1)
+                            item_connector = "└──" if is_last_item else "├──"
+                            metadata_prefix = f"{cell_prefix}    {'   ' if is_last_item else '│  '}"
+                            
+                            icon = "📊" if item_type == "technique" else "🔍"
+                            print(f"   {cell_prefix}    {item_connector} {icon} {item_name}")
+                            
+                            if show_metadata:
+                                print(f"   {metadata_prefix}    📋 ID: {item_obj.metadata.id}")
+                                print(f"   {metadata_prefix}    🏷️  Type: {item_obj.metadata.type}")
+                                if hasattr(item_obj.metadata, 'start') and item_obj.metadata.start:
+                                    duration = ""
+                                    if hasattr(item_obj.metadata, 'end') and item_obj.metadata.end:
+                                        duration = f" → {item_obj.metadata.end.strftime('%H:%M')}"
+                                    print(f"   {metadata_prefix}    📅 Time: {item_obj.metadata.start.strftime('%Y-%m-%d %H:%M')}{duration}")
+                                print(f"   {metadata_prefix}    🔧 Devices: {len(item_obj.metadata.devices)}")
+                                print(f"   {metadata_prefix}    ⚙️  Settings: {len(item_obj.metadata.settings)}")
+                            
+                            if show_data and item_obj.data.variables:
+                                data_vars = list(item_obj.data.variables.keys())
+                                print(f"   {metadata_prefix}    📊 Data vars: {', '.join(data_vars[:3])}{' ...' if len(data_vars) > 3 else ''}")
+    
+    def plot_structure(self, filename: Optional[str] = None, format: str = "svg", 
+                      show_metadata: bool = False) -> None:
+        """Create a clean hierarchical diagram using Mermaid syntax.
+        
+        Note: Formats "png", "svg", and "pdf" require an internet connection and use 
+        the external Mermaid service via mermaid-py library. Use "mmd" format to 
+        generate only the Mermaid code file for offline use.
+        
+        Args:
+            filename: Output filename (if None, uses default name)
+            format: Output format ("png", "svg", "pdf", "mmd") - SVG recommended for best quality, mmd for offline use
+            show_metadata: Whether to include metadata details in nodes
+        """
+        # Handle mmd format (Mermaid code only) without requiring mermaid-py
+        if format.lower() == "mmd":
+            if filename is None:
+                filename = "file_structure.mmd"
+            elif '.' not in filename:
+                filename = f"{filename}.mmd"
+            
+            # Generate and save Mermaid code directly
+            mermaid_code = self._generate_mermaid_graph(show_metadata)
+            with open(filename, 'w') as f:
+                f.write(mermaid_code)
+            print(f"✅ Mermaid code saved as: {filename}")
+            print("   💡 You can render this manually at: https://mermaid.live/")
+            print("   💡 Or use mermaid-cli: npx @mermaid-js/mermaid-cli -i file.mmd -o file.svg")
+            return
+        
+        # For rendering formats, check mermaid-py availability
+        try:
+            from mermaid import Mermaid
+        except ImportError:
+            print("⚠️  Cannot create structure plot: mermaid-py not installed")
+            print("   → Install with: poetry add mermaid-py")
+            print("   → Or use format='mmd' to generate Mermaid code only")
+            return
+        
+        if filename is None:
+            filename = f"file_structure.{format}"
+        elif '.' not in filename:
+            filename = f"{filename}.{format}"
+        
+        # Generate Mermaid graph syntax
+        mermaid_code = self._generate_mermaid_graph(show_metadata)
+        
+        # Create Mermaid instance and render
+        try:
+            # Create Mermaid instance with the graph code
+            mermaid = Mermaid(mermaid_code)
+            
+            # Render the diagram based on format
+            if format.lower() == "svg":
+
+                mermaid.to_svg(filename)
+                
+                # Check if file was created successfully (mermaid-py sometimes fails silently)
+                if Path(filename).exists() and Path(filename).stat().st_size > 0:
+                    print(f"✅ Structure diagram saved as: {filename}")
+                else:
+                    # SVG generation failed (likely due to service unavailability)
+                    print(f"⚠️  SVG generation failed (service may be unavailable)")
+                    raise Exception("SVG file empty or not created")
+                    
+            elif format.lower() == "pdf":
+                # PDF not directly supported by mermaid-py, fallback to SVG for better quality
+                print("   ℹ️  PDF format not supported by mermaid-py, using SVG instead")
+                svg_filename = filename.replace('.pdf', '.svg')
+                mermaid.to_svg(svg_filename)
+                
+                if Path(svg_filename).exists() and Path(svg_filename).stat().st_size > 0:
+                    filename = svg_filename
+                    print(f"✅ Structure diagram saved as: {filename}")
+                else:
+                    raise Exception("SVG file empty or not created")
+                    
+            else:  # Default to PNG
+                mermaid.to_png(filename)
+                
+                if Path(filename).exists() and Path(filename).stat().st_size > 0:
+                    print(f"✅ Structure diagram saved as: {filename}")
+                else:
+                    raise Exception("PNG file empty or not created")
+            
+        except Exception as e:
+            print(f"⚠️  Diagram generation failed: {e}")
+            print("   → This is likely due to mermaid-py service being temporarily unavailable")
+            print("   → Saving Mermaid code for manual rendering")
+            
+            # Fallback: Save Mermaid code as text file
+            text_filename = filename.replace(f".{format}", ".mmd")
+            with open(text_filename, 'w') as f:
+                f.write(mermaid_code)
+            print(f"✅ Mermaid code saved as: {text_filename}")
+            print("   💡 You can render this manually at: https://mermaid.live/")
+            print("   💡 Or use mermaid-cli: npx @mermaid-js/mermaid-cli -i file.mmd -o file.svg")
+            print("   💡 Or use format='mmd' directly to skip online rendering")
+    
+    def _generate_mermaid_graph(self, show_metadata: bool = False) -> str:
+        """Generate Mermaid Entity Relationship Diagram with group entities."""
+        lines = [
+            '%%{',
+            '   init: {',
+            '     "theme": "forest"',
+            '   }',
+            '}%%',
+            'erDiagram'
+        ]
+        lines.append("")
+        
+        # Define Study entity
+        lines.append('    "Study" {')
+        lines.append(f'        string id "{self.study_metadata.id}"')
+        if show_metadata:
+            lines.append(f'        int contributors "{len(self.study_metadata.contributors)}"')
+            lines.append(f'        int funding "{len(self.study_metadata.funding)}"')
+            lines.append(f'        datetime timestamp "{self.study_metadata.timestamp.strftime("%Y-%m-%d %H:%M")}"')
+        lines.append("    }")
+        lines.append("")
+        
+        if not self.cells:
+            lines.append('    "Empty Study" {')
+            lines.append('        string message "no_cells_defined"')
+            lines.append("    }")
+            lines.append('    "Study" ||--|| "Empty Study" : contains')
+        else:
+            # Add each cell as entity
+            for i, (cell_name, cell) in enumerate(self.cells.items()):
+                cell_entity = f'"{cell_name}"'
+                
+                lines.append(f"    {cell_entity} {{")
+                lines.append(f'        string name "{cell_name}"')
+                if show_metadata:
+                    lines.append(f'        string id "{cell.metadata.id}"')
+                    lines.append(f'        string type "{cell.metadata.type}"')
+                    lines.append(f'        int components "{len(cell.metadata.components)}"')
+                lines.append("    }")
+                lines.append("")
+                
+                # Connect study to cell
+                lines.append(f'    "Study" ||--o{{ {cell_entity} : contains')
+                lines.append("")
+                
+                # Organize items by groups
+                all_items = []
+                for tech_name, tech in cell.techniques.items():
+                    all_items.append(("technique", tech_name, tech))
+                for aux_name, aux in cell.auxiliary.items():
+                    all_items.append(("auxiliary", aux_name, aux))
+                
+                # Group items using the new group management
+                groups = {}
+                ungrouped = []
+                
+                for item_type, item_name, item_obj in all_items:
+                    # Get group info from the object's metadata
+                    group_id = item_obj.metadata.group_id
+                    group_name = item_obj.metadata.group_name
+                    
+                    if group_id is not None and group_name is not None:
+                        # Verify group exists in cell's group registry
+                        cell_group = cell.get_group_by_id(group_id)
+                        if cell_group is not None:
+                            # Use the group from cell registry (authoritative source)
+                            group_key = f"{cell_group.name}_{group_id}"
+                            
+                            if group_key not in groups:
+                                groups[group_key] = {
+                                    'name': cell_group.name,
+                                    'id': group_id,
+                                    'items': []
+                                }
+                            groups[group_key]['items'].append((item_type, item_name, item_obj))
+                        else:
+                            # Group ID not found in registry, treat as ungrouped
+                            ungrouped.append((item_type, item_name, item_obj))
+                    else:
+                        ungrouped.append((item_type, item_name, item_obj))
+                
+                # Add group entities
+                group_counter = 0
+                for group_key, group_data in groups.items():
+                    group_counter += 1
+                    # Make group entity name unique by including cell name
+                    group_entity = f'"{cell_name}_{group_data["name"]}"'
+                    
+                    lines.append(f"    {group_entity} {{")
+                    lines.append(f'        string name "{group_data["name"]}"')
+                    if show_metadata:
+                        if group_data['id'] is not None:
+                            lines.append(f'        int group_id "{group_data["id"]}"')
+                        lines.append(f'        int items "{len(group_data["items"])}"')
+                    lines.append("    }")
+                    lines.append("")
+                    
+                    # Connect cell to group
+                    lines.append(f"    {cell_entity} ||--o{{ {group_entity} : performed")
+                    lines.append("")
+                    
+                    # Add items within the group
+                    item_counter = 0
+                    for item_type, item_name, item_obj in group_data['items']:
+                        item_counter += 1
+                        # Make item entity name unique by including cell name
+                        item_entity = f'"{cell_name}_{item_name}"'
+                        
+                        lines.append(f"    {item_entity} {{")
+                        lines.append(f'        string name "{item_name.split("_")[-1]}"')
+                        if show_metadata:
+                            lines.append(f'        int id "{item_obj.metadata.id}"')
+                            lines.append(f'        string type "{item_obj.metadata.type}"')
+                            lines.append(f'        datetime start "{item_obj.metadata.start.strftime("%Y-%m-%d %H:%M:%S") if item_obj.metadata.start else "N/A"}"')
+                            lines.append(f'        datetime end "{item_obj.metadata.end.strftime("%Y-%m-%d %H:%M:%S") if item_obj.metadata.end else "N/A"}"')
+                            lines.append(f'        int devices "{len(item_obj.metadata.devices)}"')
+                            lines.append(f'        int settings "{len(item_obj.metadata.settings)}"')
+
+                        lines.append("    }")
+                        lines.append("")
+                        
+                        # Connect group to item
+                        lines.append(f"    {group_entity} ||--|| {item_entity} : includes")
+                        lines.append("")
+                
+                # Add ungrouped items directly to cell
+                ungrouped_counter = 0
+                for item_type, item_name, item_obj in ungrouped:
+                    ungrouped_counter += 1
+                    # Make item entity name unique by including cell name
+                    item_entity = f'"{cell_name}_{item_name}"'
+                    
+                    lines.append(f"    {item_entity} {{")
+                    lines.append(f'        string name "{item_name.split("_")[-1]}"')
+                    if show_metadata:
+                        lines.append(f'        int id "{item_obj.metadata.id}"')
+                        lines.append(f'        string type "{item_obj.metadata.type}"')
+                        lines.append(f'        datetime start "{item_obj.metadata.start.strftime("%Y-%m-%d %H:%M:%S") if item_obj.metadata.start else "N/A"}"')
+                        lines.append(f'        datetime end "{item_obj.metadata.end.strftime("%Y-%m-%d %H:%M:%S") if item_obj.metadata.end else "N/A"}"')
+                        lines.append(f'        int devices "{len(item_obj.metadata.devices)}"')
+                        lines.append(f'        int settings "{len(item_obj.metadata.settings)}"')
+                    lines.append("    }")
+                    lines.append("")
+                    
+                    # Connect cell directly to ungrouped item
+                    lines.append(f"    {cell_entity} ||--|| {item_entity} : performed")
+                    lines.append("")
+        
+        return "\n".join(lines)
+    
+

--- a/src/echem_data_tool/file/metadata.py
+++ b/src/echem_data_tool/file/metadata.py
@@ -1,0 +1,1579 @@
+# Copyright (C) 2025 Friedrich-Schiller-Universität Jena, HIPOLE Jena
+# Authors: Christian Stolze, Sebastian Witt, Felix Nagler
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Metadata handling module for electrochemical netCDF files.
+
+This module provides classes for handling metadata in the
+hierarchical netCDF files defined in the file format specification 
+found in `design-docs/file_format_specs.md`.
+
+The module abstracts xarray/netCDF complexity and provides a clean interface
+for managing metadata across the hierarchical structure:
+
+- Study-level metadata (root/global attributes)
+- Cell-level metadata (cell group attributes) 
+- Group-level metadata (organizational units for techniques/auxiliaries)
+- Technique-level metadata (technique group attributes)  
+- Auxiliary data metadata (auxiliary group attributes)
+
+All metadata classes follow the Battery Data Genome (BDG) tier-based
+organization with primary, secondary, and tertiary metadata levels.
+
+Minimal example:
+    ```python
+    from echem_data_tool.file import FileObject
+    
+    # Create file object (includes StudyMetadata automatically)
+    file_obj = FileObject()
+    file_obj.metadata.id = "20250928_test_experiment"
+    file_obj.metadata.description = "Example electrochemical study"
+    file_obj.metadata.add_contributor("Jane Doe", "jane@example.edu", "Example Uni")
+    
+    # Add cell with metadata
+    cell = file_obj.add_cell("cell_001")
+    cell.metadata.id = "Cell-001"
+    cell.metadata.type = "Three-electrode cell"
+    cell.metadata.cathode = "Ferrocene"
+    cell.metadata.anode = "Zn"
+    cell.metadata.electrolyte = "ZnSO4 (aq)"
+    
+    # Add technique with metadata
+    cv_tech = cell.add_technique("technique_001_CV")
+    cv_tech.metadata.type = "Cyclic Voltammetry"
+    cv_tech.metadata.add_setting("scan_rate", 0.1, "V/s")
+    ```
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+import xarray as xr
+
+
+@dataclass
+class Contributor:
+    """Represents a contributor to the study.
+    
+    Attributes:
+        name: Full name of the contributor
+        email: Email address
+        affiliation: Institution/organization
+        additional_info: List of additional information as name-value pairs
+    """
+    name: str
+    email: str
+    affiliation: str
+    additional_info: List[Dict[str, str]] = field(default_factory=list)
+    
+    def add_additional_info(self, name: str, value: str) -> None:
+        """Add additional information (e.g., ORCID, contribution type)."""
+        self.additional_info.append({"name": name, "value": value})
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "name": self.name,
+            "email": self.email,
+            "affiliation": self.affiliation,
+            "additional_info": self.additional_info
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> Contributor:
+        """Create Contributor from dictionary representation."""
+        return cls(
+            name=data["name"],
+            email=data["email"],
+            affiliation=data["affiliation"],
+            additional_info=data.get("additional_info", [])
+        )
+
+
+@dataclass
+class Funding:
+    """Represents funding information.
+    
+    Attributes:
+        agency: Funding agency name
+        country: Country code or name
+        grant_number: Grant/project number
+    """
+    agency: str
+    country: str
+    grant_number: str
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "agency": self.agency,
+            "country": self.country,
+            "grant_number": self.grant_number
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> Funding:
+        """Create Funding from dictionary representation."""
+        return cls(
+            agency=data["agency"],
+            country=data["country"],
+            grant_number=data["grant_number"]
+        )
+
+
+@dataclass
+class SoftwareObject:
+    """Represents software information.
+    
+    Attributes:
+        name: Software name
+        version: Software version
+    """
+    name: str
+    version: str
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "name": self.name,
+            "version": self.version
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> SoftwareObject:
+        """Create SoftwareObject from dictionary representation."""
+        return cls(
+            name=data["name"],
+            version=data["version"]
+        )
+
+
+@dataclass
+class Device:
+    """Represents a device/instrument used in measurements.
+    
+    Attributes:
+        name: Device name/identifier
+        type: Type of device (potentiostat, sensor, etc.)
+        manufacturer: Manufacturer name
+        model: Model number/name
+        software: Software object (optional)
+    """
+    name: str
+    type: str
+    manufacturer: str
+    model: str
+    software: Optional[SoftwareObject] = None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        result = {
+            "name": self.name,
+            "type": self.type,
+            "manufacturer": self.manufacturer,
+            "model": self.model
+        }
+        if self.software:
+            result["software"] = self.software.to_dict()
+        return result
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> Device:
+        """Create Device from dictionary representation."""
+        software = None
+        if "software" in data:
+            software = SoftwareObject.from_dict(data["software"])
+        
+        return cls(
+            name=data["name"],
+            type=data["type"],
+            manufacturer=data["manufacturer"],
+            model=data["model"],
+            software=software
+        )
+
+
+@dataclass
+class Parameter:
+    """Represents a measurement parameter or property.
+    
+    Attributes:
+        name: Parameter name
+        value: Parameter value (can be numeric, string, or list)
+        unit: Unit of measurement (optional)
+    """
+    name: str
+    value: Union[str, int, float, List[Any]]
+    unit: Optional[str] = None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        result = {
+            "name": self.name,
+            "value": self.value
+        }
+        if self.unit is not None:
+            result["unit"] = self.unit
+        return result
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> Parameter:
+        """Create Parameter from dictionary representation."""
+        return cls(
+            name=data["name"],
+            value=data["value"],
+            unit=data.get("unit")
+        )
+
+
+@dataclass
+class AmountObject:
+    """Represents an amount with value and unit.
+    
+    Attributes:
+        value: Amount value
+        unit: Unit of measurement
+    """
+    value: Union[int, float]
+    unit: str
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "value": self.value,
+            "unit": self.unit
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AmountObject:
+        """Create AmountObject from dictionary representation."""
+        return cls(
+            value=data["value"],
+            unit=data["unit"]
+        )
+
+
+@dataclass
+class Material:
+    """Represents a material component.
+    
+    Attributes:
+        name: Material name
+        type: Material type (active_material, binder, etc.)
+        amount: Amount object with value and unit
+        id: Optional material ID for tracking
+    """
+    name: str
+    type: str
+    amount: AmountObject
+    id: Optional[str] = None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        result = {
+            "name": self.name,
+            "type": self.type,
+            "amount": self.amount.to_dict()
+        }
+        if self.id:
+            result["id"] = self.id
+        return result
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> Material:
+        """Create Material from dictionary representation."""
+        return cls(
+            name=data["name"],
+            type=data["type"],
+            amount=AmountObject.from_dict(data["amount"]),
+            id=data.get("id")
+        )
+
+
+@dataclass
+class CellComponent:
+    """Represents a cell component (electrode, separator, etc.).
+    
+    Attributes:
+        name: Component name
+        materials: List of materials in the component
+        procedures: List of manufacturing/preparation procedures
+        properties: List of physical/chemical properties
+    """
+    name: str
+    materials: List[Material] = field(default_factory=list)
+    procedures: List[Parameter] = field(default_factory=list)
+    properties: List[Parameter] = field(default_factory=list)
+    
+    def add_material(self, name: str, type: str, amount_value: Union[int, float], amount_unit: str, id: Optional[str] = None) -> Material:
+        """Add a material to this component."""
+        amount = AmountObject(value=amount_value, unit=amount_unit)
+        material = Material(name=name, type=type, amount=amount, id=id)
+        self.materials.append(material)
+        return material
+    
+    def add_procedure(self, name: str, value: Union[str, int, float, List[Any]], 
+                     unit: Optional[str] = None) -> Parameter:
+        """Add a procedure parameter."""
+        procedure = Parameter(name=name, value=value, unit=unit)
+        self.procedures.append(procedure)
+        return procedure
+    
+    def add_property(self, name: str, value: Union[str, int, float, List[Any]], 
+                    unit: Optional[str] = None) -> Parameter:
+        """Add a property parameter."""
+        property_param = Parameter(name=name, value=value, unit=unit)
+        self.properties.append(property_param)
+        return property_param
+    
+    def find_material(self, name: str) -> Optional[Material]:
+        """Find a material by name."""
+        for material in self.materials:
+            if material.name == name:
+                return material
+        return None
+    
+    def find_procedure(self, name: str) -> Optional[Parameter]:
+        """Find a procedure by name."""
+        for procedure in self.procedures:
+            if procedure.name == name:
+                return procedure
+        return None
+    
+    def find_property(self, name: str) -> Optional[Parameter]:
+        """Find a property by name."""
+        for property_param in self.properties:
+            if property_param.name == name:
+                return property_param
+        return None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "name": self.name,
+            "materials": [mat.to_dict() for mat in self.materials],
+            "procedures": [proc.to_dict() for proc in self.procedures],
+            "properties": [prop.to_dict() for prop in self.properties]
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> CellComponent:
+        """Create CellComponent from dictionary representation."""
+        component = cls(name=data["name"])
+        
+        # Reconstruct materials
+        for mat_data in data.get("materials", []):
+            component.materials.append(Material.from_dict(mat_data))
+        
+        # Reconstruct procedures
+        for proc_data in data.get("procedures", []):
+            component.procedures.append(Parameter.from_dict(proc_data))
+        
+        # Reconstruct properties
+        for prop_data in data.get("properties", []):
+            component.properties.append(Parameter.from_dict(prop_data))
+        
+        return component
+
+
+@dataclass
+class ChemistryObject:
+    """Represents chemistry notation.
+    
+    Attributes:
+        cathode: Cathode description
+        anode: Anode description
+        electrolyte: Electrolyte type description
+    """
+    cathode: str
+    anode: str
+    electrolyte: str
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "cathode": self.cathode,
+            "anode": self.anode,
+            "electrolyte": self.electrolyte
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ChemistryObject:
+        """Create ChemistryObject from dictionary representation."""
+        return cls(
+            cathode=data["cathode"],
+            anode=data["anode"],
+            electrolyte=data["electrolyte"]
+        )
+
+
+@dataclass
+class AssemblyObject:
+    """Represents assembly information.
+    
+    Attributes:
+        timestamp: Assembly timestamp (optional)
+        manufacturer: Assembly manufacturer/provider/institution
+        environment: Assembly environment description
+    """
+    timestamp: Optional[datetime] = None
+    manufacturer: str = ""
+    environment: str = ""
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        result = {
+            "manufacturer": self.manufacturer,
+            "environment": self.environment
+        }
+        if self.timestamp:
+            result["timestamp"] = self.timestamp.isoformat()
+        return result
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AssemblyObject:
+        """Create AssemblyObject from dictionary representation."""
+        timestamp = None
+        if "timestamp" in data:
+            timestamp = datetime.fromisoformat(data["timestamp"])
+        
+        return cls(
+            timestamp=timestamp,
+            manufacturer=data.get("manufacturer", ""),
+            environment=data.get("environment", "")
+        )
+
+
+
+
+
+@dataclass
+class AdditionalNote:
+    """Represents an additional note with name and value.
+    
+    Attributes:
+        name: Short name for identification
+        value: Note value content
+    """
+    name: str
+    value: str
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "name": self.name,
+            "value": self.value
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AdditionalNote:
+        """Create AdditionalNote from dictionary representation."""
+        return cls(
+            name=data["name"],
+            value=data["value"]
+        )
+
+
+class BaseMetadata(ABC):
+    """Abstract base class for all metadata types.
+    
+    Provides common functionality for handling BDG tier-based metadata
+    organization and conversion to/from netCDF attributes.
+    """
+    
+    @abstractmethod
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert metadata to dictionary representation."""
+        pass
+    
+    @abstractmethod
+    def to_json(self) -> str:
+        """Convert metadata to JSON string."""
+        pass
+    
+    @abstractmethod
+    def to_netcdf_attrs(self) -> Dict[str, Any]:
+        """Convert to netCDF-compatible attributes.
+        
+        NetCDF attributes have limitations (no nested objects),
+        so complex structures are serialized as JSON strings.
+        """
+        pass
+    
+    @classmethod
+    @abstractmethod
+    def from_netcdf_attrs(cls, attrs: Dict[str, Any]) -> BaseMetadata:
+        """Create metadata object from netCDF attributes."""
+        pass
+
+
+class StudyMetadata(BaseMetadata):
+    """Study-level metadata for the root group.
+    
+    Contains file format metadata and essential study-wide parameters
+    following BDG tier-based organization.
+    
+    Attributes:
+        format_version: File format version
+        timestamp: Creation timestamp of netCDF file
+        id: Study identifier
+        description: Study description
+        contributors: List of contributors
+        funding: List of funding sources
+    """
+    
+    def __init__(self, id: str = "", description: str = "", 
+                 format_version: str = "1.0.0",
+                 timestamp: Optional[datetime] = None):
+        self.format_version = format_version
+        self.timestamp = timestamp or datetime.now()
+        self.id = id
+        self.description = description
+        self.contributors: List[Contributor] = []
+        self.funding: List[Funding] = []
+    
+    def add_contributor(self, name: str, email: str, affiliation: str, 
+                       additional_info: Optional[List[tuple]] = None) -> Contributor:
+        """Add a contributor to the study.
+        
+        Args:
+            name: Full name of the contributor
+            email: Email address
+            affiliation: Institution/organization
+            additional_info: Optional list of additional info tuples: (name, value)
+                           e.g., [("orcid", "0000-0000-0000-0000"), ("role", "Principal Investigator")]
+            
+        Returns:
+            The created Contributor object
+        """
+        contributor = Contributor(name=name, email=email, affiliation=affiliation)
+        
+        if additional_info:
+            for info_data in additional_info:
+                if len(info_data) >= 2:
+                    contributor.add_additional_info(info_data[0], str(info_data[1]))
+        
+        self.contributors.append(contributor)
+        return contributor
+    
+    def add_funding(self, agency: str, country: str, grant_number: str) -> Funding:
+        """Add funding information."""
+        funding = Funding(agency=agency, country=country, grant_number=grant_number)
+        self.funding.append(funding)
+        return funding
+    
+    def find_contributor(self, name: str) -> Optional[Contributor]:
+        """Find a contributor by name."""
+        for contributor in self.contributors:
+            if contributor.name == name:
+                return contributor
+        return None
+    
+    def find_funding(self, agency: str) -> Optional[Funding]:
+        """Find funding by agency name."""
+        for funding in self.funding:
+            if funding.agency == agency:
+                return funding
+        return None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        return {
+            "file_metadata": {
+                "format_version": self.format_version,
+                "timestamp": self.timestamp.isoformat()
+            },
+            "study_metadata": {
+                "id": self.id,
+                "description": self.description,
+                "contributors": [contrib.to_dict() for contrib in self.contributors],
+                "funding": [fund.to_dict() for fund in self.funding]
+            }
+        }
+    
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+    
+    def to_netcdf_attrs(self) -> Dict[str, Any]:
+        """Convert to netCDF-compatible attributes."""
+        # Store complex structures as JSON strings for netCDF compatibility
+        return {
+            "format_version": self.format_version,
+            "timestamp": self.timestamp.isoformat(),
+            "study_id": self.id,
+            "study_description": self.description,
+            "study_metadata_json": json.dumps(self.to_dict())
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> StudyMetadata:
+        """Create StudyMetadata from dictionary representation."""
+        file_metadata = data.get("file_metadata", {})
+        study_metadata = data.get("study_metadata", {})
+        
+        study = cls(
+            id=study_metadata.get("id", ""),
+            description=study_metadata.get("description", ""),
+            format_version=file_metadata.get("format_version", "1.0.0"),
+            timestamp=datetime.fromisoformat(file_metadata["timestamp"]) if "timestamp" in file_metadata else datetime.now()
+        )
+        
+        # Reconstruct contributors
+        for contrib_data in study_metadata.get("contributors", []):
+            study.contributors.append(Contributor.from_dict(contrib_data))
+        
+        # Reconstruct funding
+        for fund_data in study_metadata.get("funding", []):
+            study.funding.append(Funding.from_dict(fund_data))
+        
+        return study
+    
+    @classmethod
+    def from_json(cls, json_str: str) -> StudyMetadata:
+        """Create StudyMetadata from JSON string."""
+        data = json.loads(json_str)
+        return cls.from_dict(data)
+    
+    @classmethod
+    def from_netcdf_attrs(cls, attrs: Dict[str, Any]) -> StudyMetadata:
+        """Create from netCDF attributes."""
+        # Try to load from JSON first, fallback to individual attributes
+        if "study_metadata_json" in attrs:
+            data = json.loads(attrs["study_metadata_json"])
+            study = cls(
+                id=data["study_metadata"]["id"],
+                description=data["study_metadata"]["description"],
+                format_version=data["file_metadata"]["format_version"],
+                timestamp=datetime.fromisoformat(data["file_metadata"]["timestamp"])
+            )
+            # Reconstruct contributors and funding
+            for contrib_data in data["study_metadata"].get("contributors", []):
+                contributor = Contributor(
+                    name=contrib_data["name"],
+                    email=contrib_data["email"],
+                    affiliation=contrib_data["affiliation"],
+                    additional_info=contrib_data.get("additional_info", [])
+                )
+                study.contributors.append(contributor)
+            
+            for fund_data in data["study_metadata"].get("funding", []):
+                funding = Funding(
+                    agency=fund_data["agency"],
+                    country=fund_data["country"],
+                    grant_number=fund_data["grant_number"]
+                )
+                study.funding.append(funding)
+            
+            return study
+        else:
+            # Fallback to individual attributes
+            return cls(
+                id=attrs.get("study_id", ""),
+                description=attrs.get("study_description", ""),
+                format_version=attrs.get("format_version", "1.0.0"),
+                timestamp=datetime.fromisoformat(attrs["timestamp"]) if "timestamp" in attrs else datetime.now()
+            )
+
+
+class CellMetadata(BaseMetadata):
+    """Cell-level metadata for cell groups.
+    
+    Contains physical and configuration details for electrochemical cells
+    following BDG tier-based organization.
+    
+    Attributes:
+        id: Cell identifier  
+        type: Cell type description
+        objective: Cell objective description
+        chemistry: Chemistry object
+        assembly: Assembly object
+        nominal_capacity_ah: Nominal capacity in Ah
+        components: List of cell components (electrodes, separator, electrolyte, etc.)
+        additional_notes: Additional notes
+    """
+    
+    def __init__(self, id: str = "", type: str = "", 
+                 cathode: str = "", anode: str = "", electrolyte: str = "",
+                 objective: str = "",
+                 nominal_capacity_ah: Optional[float] = None,
+                 assembly_timestamp: Optional[datetime] = None,
+                 assembly_manufacturer: str = "",
+                 assembly_environment: str = ""):
+        self.id = id
+        self.type = type
+        self.objective = objective
+        self.chemistry = ChemistryObject(cathode=cathode, anode=anode, electrolyte=electrolyte)
+        self.assembly = AssemblyObject(timestamp=assembly_timestamp, manufacturer=assembly_manufacturer, environment=assembly_environment)
+        self.nominal_capacity_ah = nominal_capacity_ah
+        self.components: List[CellComponent] = []
+        self.additional_notes: List[AdditionalNote] = []
+    
+    @property
+    def cathode(self) -> str:
+        """Get the cathode material."""
+        return self.chemistry.cathode
+    
+    @cathode.setter
+    def cathode(self, value: str):
+        """Set the cathode material."""
+        self.chemistry.cathode = value
+    
+    @property
+    def anode(self) -> str:
+        """Get the anode material."""
+        return self.chemistry.anode
+    
+    @anode.setter
+    def anode(self, value: str):
+        """Set the anode material."""
+        self.chemistry.anode = value
+    
+    @property
+    def electrolyte(self) -> str:
+        """Get the electrolyte material."""
+        return self.chemistry.electrolyte
+    
+    @electrolyte.setter
+    def electrolyte(self, value: str):
+        """Set the electrolyte material."""
+        self.chemistry.electrolyte = value
+    
+    @property
+    def assembly_timestamp(self) -> Optional[datetime]:
+        """Get the assembly timestamp."""
+        return self.assembly.timestamp
+    
+    @assembly_timestamp.setter
+    def assembly_timestamp(self, value: Optional[datetime]):
+        """Set the assembly timestamp."""
+        self.assembly.timestamp = value
+    
+    @property
+    def assembly_manufacturer(self) -> str:
+        """Get the assembly manufacturer."""
+        return self.assembly.manufacturer
+    
+    @assembly_manufacturer.setter
+    def assembly_manufacturer(self, value: str):
+        """Set the assembly manufacturer."""
+        self.assembly.manufacturer = value
+    
+    @property
+    def assembly_environment(self) -> str:
+        """Get the assembly environment."""
+        return self.assembly.environment
+    
+    @assembly_environment.setter
+    def assembly_environment(self, value: str):
+        """Set the assembly environment."""
+        self.assembly.environment = value
+    
+    def add_component(self, name: str, materials: Optional[List[tuple]] = None,
+                     procedures: Optional[List[tuple]] = None,
+                     properties: Optional[List[tuple]] = None) -> CellComponent:
+        """Add a cell component (electrode, separator, electrolyte, etc.).
+        
+        Args:
+            name: Component name (e.g., "cathode", "anode", "electrolyte")
+            materials: Optional list of material tuples: (name, type, amount_value, amount_unit)
+                      e.g., [("LiFePO4", "active_material", 85.0, "wt%"), ("Carbon", "additive", 10.0, "wt%")]
+            procedures: Optional list of procedure tuples: (name, value, unit)
+                       e.g., [("drying_temperature", 80, "°C"), ("coating_method", "doctor blade", None)]
+            properties: Optional list of property tuples: (name, value, unit)
+                       e.g., [("diameter", 0.6, "cm"), ("mass", 0.00100, "g")]
+                      
+        Returns:
+            The created CellComponent object
+        """
+        component = CellComponent(name=name)
+        
+        if materials:
+            for material_data in materials:
+                if len(material_data) >= 4:
+                    id_param = material_data[4] if len(material_data) >= 5 else None
+                    component.add_material(material_data[0], material_data[1], material_data[2], material_data[3], id_param)
+        
+        if procedures:
+            for procedure_data in procedures:
+                if len(procedure_data) >= 2:
+                    name_param, value_param = procedure_data[0], procedure_data[1]
+                    unit_param = procedure_data[2] if len(procedure_data) >= 3 else None
+                    component.add_procedure(name_param, value_param, unit_param)
+        
+        if properties:
+            for property_data in properties:
+                if len(property_data) >= 2:
+                    name_param, value_param = property_data[0], property_data[1]
+                    unit_param = property_data[2] if len(property_data) >= 3 else None
+                    component.add_property(name_param, value_param, unit_param)
+        
+        self.components.append(component)
+        return component
+    
+    def add_note(self, name: str, value: str) -> AdditionalNote:
+        """Add an additional note."""
+        note = AdditionalNote(name=name, value=value)
+        self.additional_notes.append(note)
+        return note
+    
+    def find_component(self, name: str) -> Optional[CellComponent]:
+        """Find a component by name."""
+        for component in self.components:
+            if component.name == name:
+                return component
+        return None
+    
+    def find_note(self, name: str) -> Optional[AdditionalNote]:
+        """Find a note by name."""
+        for note in self.additional_notes:
+            if note.name == name:
+                return note
+        return None
+    
+
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        primary = {
+            "id": self.id,
+            "type": self.type,
+            "chemistry": self.chemistry.to_dict(),
+            "assembly": self.assembly.to_dict()
+        }
+        
+        if self.objective:
+            primary["objective"] = self.objective
+        if self.nominal_capacity_ah is not None:
+            primary["nominal_capacity_ah"] = self.nominal_capacity_ah
+        
+        secondary = {}
+        if self.components:
+            secondary["components"] = [comp.to_dict() for comp in self.components]
+        
+        result = {
+            "primary": primary,
+        }
+        
+        if secondary:
+            result["secondary"] = secondary
+        
+        if self.additional_notes:
+            result["tertiary"] = {
+                "additional_notes": [note.to_dict() for note in self.additional_notes]
+            }
+        
+        return result
+    
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+    
+    def to_netcdf_attrs(self) -> Dict[str, Any]:
+        """Convert to netCDF-compatible attributes."""
+        return {
+            "cell_id": self.id,
+            "cell_type": self.type,
+            "cell_cathode": self.chemistry.cathode,
+            "cell_anode": self.chemistry.anode,
+            "cell_electrolyte": self.chemistry.electrolyte,
+            "cell_metadata_json": json.dumps(self.to_dict())
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> CellMetadata:
+        """Create CellMetadata from dictionary representation."""
+        primary = data.get("primary", {})
+        secondary = data.get("secondary", {})
+        tertiary = data.get("tertiary", {})
+        
+        # Extract chemistry and assembly objects
+        chemistry_data = primary.get("chemistry", {})
+        assembly_data = primary.get("assembly", {})
+        
+        cell = cls(
+            id=primary.get("id", ""),
+            type=primary.get("type", ""),
+            cathode=chemistry_data.get("cathode", ""),
+            anode=chemistry_data.get("anode", ""),
+            electrolyte=chemistry_data.get("electrolyte", ""),
+            objective=primary.get("objective", ""),
+            nominal_capacity_ah=primary.get("nominal_capacity_ah"),
+            assembly_timestamp=datetime.fromisoformat(assembly_data["timestamp"]) if "timestamp" in assembly_data else None,
+            assembly_manufacturer=assembly_data.get("manufacturer", ""),
+            assembly_environment=assembly_data.get("environment", "")
+        )
+        
+        # Reconstruct components
+        for comp_data in secondary.get("components", []):
+            cell.components.append(CellComponent.from_dict(comp_data))
+        
+        # Reconstruct additional notes
+        for note_data in tertiary.get("additional_notes", []):
+            cell.additional_notes.append(AdditionalNote.from_dict(note_data))
+        
+        return cell
+    
+    @classmethod
+    def from_json(cls, json_str: str) -> CellMetadata:
+        """Create CellMetadata from JSON string."""
+        data = json.loads(json_str)
+        return cls.from_dict(data)
+    
+    @classmethod
+    def from_netcdf_attrs(cls, attrs: Dict[str, Any]) -> CellMetadata:
+        """Create from netCDF attributes."""
+        if "cell_metadata_json" in attrs:
+            data = json.loads(attrs["cell_metadata_json"])
+            primary = data["primary"]
+            
+            # Extract chemistry and assembly objects
+            chemistry_data = primary.get("chemistry", {})
+            assembly_data = primary.get("assembly", {})
+            
+            cell = cls(
+                id=primary["id"],
+                type=primary["type"],
+                cathode=chemistry_data.get("cathode", ""),
+                anode=chemistry_data.get("anode", ""),
+                electrolyte=chemistry_data.get("electrolyte", ""),
+                objective=primary.get("objective", ""),
+                nominal_capacity_ah=primary.get("nominal_capacity_ah"),
+                assembly_timestamp=datetime.fromisoformat(assembly_data["timestamp"]) if "timestamp" in assembly_data else None,
+                assembly_manufacturer=assembly_data.get("manufacturer", ""),
+                assembly_environment=assembly_data.get("environment", "")
+            )
+            
+            # Reconstruct components
+            secondary = data.get("secondary", {})
+            for comp_data in secondary.get("components", []):
+                component = CellComponent(name=comp_data["name"])
+                # Reconstruct materials, procedures, properties
+                for mat_data in comp_data.get("materials", []):
+                    component.materials.append(Material.from_dict(mat_data))
+                for proc_data in comp_data.get("procedures", []):
+                    component.procedures.append(Parameter.from_dict(proc_data))
+                for prop_data in comp_data.get("properties", []):
+                    component.properties.append(Parameter.from_dict(prop_data))
+                cell.components.append(component)
+            
+            # Reconstruct additional notes
+            tertiary = data.get("tertiary", {})
+            for note_data in tertiary.get("additional_notes", []):
+                cell.additional_notes.append(AdditionalNote.from_dict(note_data))
+            
+            return cell
+        else:
+            # Fallback to individual attributes
+            return cls(
+                id=attrs.get("cell_id", ""),
+                type=attrs.get("cell_type", ""),
+                cathode=attrs.get("cell_cathode", ""),
+                anode=attrs.get("cell_anode", ""),
+                electrolyte=attrs.get("cell_electrolyte", "")
+            )
+
+
+class TechniqueMetadata(BaseMetadata):
+    """Technique-level metadata for technique groups.
+    
+    Contains parameters and conditions for electrochemical measurements
+    following BDG tier-based organization.
+    
+    Attributes:
+        id: Technique sequence ID
+        type: Technique type (CV, OCV, cycling, etc.)
+        start: Start timestamp
+        end: End timestamp (optional)
+        auxiliary: Whether this is auxiliary data (always False for techniques)
+        group_id: Group ID
+        group_name: Group name
+        devices: List of devices used
+        settings: List of measurement settings
+        additional_notes: Additional notes
+    """
+    
+    def __init__(self, id: int = 0, type: str = "", start: Optional[datetime] = None,
+                 end: Optional[datetime] = None):
+        self.id = id
+        self.type = type
+        self.start = start if start is not None else datetime.now()
+        self.end = end
+        self.auxiliary = False
+        self.group_id: Optional[int] = None
+        self.group_name: Optional[str] = None
+        self.devices: List[Device] = []
+        self.settings: List[Parameter] = []
+        self.additional_notes: List[AdditionalNote] = []
+    
+    def add_device(self, name: str, type: str, manufacturer: str, model: str,
+                  software_name: Optional[str] = None, software_version: Optional[str] = None) -> Device:
+        """Add a device used in this technique."""
+        software = None
+        if software_name and software_version:
+            software = SoftwareObject(name=software_name, version=software_version)
+        
+        device = Device(
+            name=name, type=type, manufacturer=manufacturer, model=model,
+            software=software
+        )
+        self.devices.append(device)
+        return device
+    
+    def add_setting(self, name: str, value: Union[str, int, float, List[Any]], 
+                   unit: Optional[str] = None) -> Parameter:
+        """Add a measurement setting."""
+        setting = Parameter(name=name, value=value, unit=unit)
+        self.settings.append(setting)
+        return setting
+    
+    def add_note(self, name: str, value: str) -> AdditionalNote:
+        """Add an additional note."""
+        note = AdditionalNote(name=name, value=value)
+        self.additional_notes.append(note)
+        return note
+    
+
+    
+    def find_device(self, name: str) -> Optional[Device]:
+        """Find a device by name."""
+        for device in self.devices:
+            if device.name == name:
+                return device
+        return None
+    
+    def find_setting(self, name: str) -> Optional[Parameter]:
+        """Find a setting by name."""
+        for setting in self.settings:
+            if setting.name == name:
+                return setting
+        return None
+    
+    def find_note(self, name: str) -> Optional[AdditionalNote]:
+        """Find a note by name."""
+        for note in self.additional_notes:
+            if note.name == name:
+                return note
+        return None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        primary = {
+            "id": self.id,
+            "auxiliary": self.auxiliary,
+            "type": self.type,
+            "start": self.start.isoformat(),
+        }
+        
+        if self.group_id is not None:
+            primary["group_id"] = self.group_id
+        if self.group_name is not None:
+            primary["group_name"] = self.group_name
+        if self.end:
+            primary["end"] = self.end.isoformat()
+        
+        secondary = {}
+        if self.devices:
+            secondary["devices"] = [device.to_dict() for device in self.devices]
+        if self.settings:
+            secondary["settings"] = [setting.to_dict() for setting in self.settings]
+        
+        result = {"primary": primary}
+        
+        if secondary:
+            result["secondary"] = secondary
+        
+        if self.additional_notes:
+            result["tertiary"] = {
+                "additional_notes": [note.to_dict() for note in self.additional_notes]
+            }
+        
+        return result
+    
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+    
+    def to_netcdf_attrs(self) -> Dict[str, Any]:
+        """Convert to netCDF-compatible attributes."""
+        return {
+            "technique_id": self.id,
+            "technique_type": self.type,
+            "technique_start": self.start.isoformat(),
+            "technique_auxiliary": self.auxiliary,
+            "technique_metadata_json": json.dumps(self.to_dict())
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> TechniqueMetadata:
+        """Create TechniqueMetadata from dictionary representation."""
+        primary = data.get("primary", {})
+        secondary = data.get("secondary", {})
+        tertiary = data.get("tertiary", {})
+        
+        technique = cls(
+            id=primary.get("id", 0),
+            type=primary.get("type", ""),
+            start=datetime.fromisoformat(primary["start"]) if "start" in primary else datetime.now(),
+            end=datetime.fromisoformat(primary["end"]) if "end" in primary else None,
+            auxiliary=primary.get("auxiliary", False) if isinstance(primary.get("auxiliary"), bool) else primary.get("auxiliary", "False").lower() == "true"
+        )
+        
+        # Reconstruct devices
+        for device_data in secondary.get("devices", []):
+            technique.devices.append(Device.from_dict(device_data))
+        
+        # Reconstruct settings
+        for setting_data in secondary.get("settings", []):
+            technique.settings.append(Parameter.from_dict(setting_data))
+        
+        # Reconstruct additional notes
+        for note_data in tertiary.get("additional_notes", []):
+            technique.additional_notes.append(AdditionalNote.from_dict(note_data))
+        
+        return technique
+    
+    @classmethod
+    def from_json(cls, json_str: str) -> TechniqueMetadata:
+        """Create TechniqueMetadata from JSON string."""
+        data = json.loads(json_str)
+        return cls.from_dict(data)
+    
+    @classmethod
+    def from_netcdf_attrs(cls, attrs: Dict[str, Any]) -> TechniqueMetadata:
+        """Create from netCDF attributes."""
+        if "technique_metadata_json" in attrs:
+            data = json.loads(attrs["technique_metadata_json"])
+            primary = data["primary"]
+            
+            technique = cls(
+                id=primary["id"],
+                type=primary["type"],
+                start=datetime.fromisoformat(primary["start"]),
+                end=datetime.fromisoformat(primary["end"]) if "end" in primary else None,
+                auxiliary=primary.get("auxiliary", False) if isinstance(primary.get("auxiliary"), bool) else primary.get("auxiliary", "False").lower() == "true"
+            )
+            
+            # Reconstruct devices and settings
+            secondary = data.get("secondary", {})
+            for device_data in secondary.get("devices", []):
+                technique.devices.append(Device.from_dict(device_data))
+            
+            for setting_data in secondary.get("settings", []):
+                technique.settings.append(Parameter.from_dict(setting_data))
+            
+            # Reconstruct additional notes
+            tertiary = data.get("tertiary", {})
+            for note_data in tertiary.get("additional_notes", []):
+                technique.additional_notes.append(AdditionalNote.from_dict(note_data))
+            
+            return technique
+        else:
+            # Fallback to individual attributes
+            return cls(
+                id=attrs.get("technique_id", 0),
+                type=attrs.get("technique_type", ""),
+                start=datetime.fromisoformat(attrs["technique_start"]) if "technique_start" in attrs else datetime.now(),
+                auxiliary=attrs.get("technique_auxiliary", False)
+            )
+
+
+class AuxiliaryMetadata(BaseMetadata):
+    """Auxiliary data metadata for auxiliary groups.
+    
+    Contains information for parallel measurements and monitoring
+    following BDG tier-based organization.
+    
+    Attributes:
+        id: Auxiliary sequence ID
+        type: Data type (temperature, UV-Vis, etc.)
+        start: Start timestamp
+        end: End timestamp (optional)  
+        auxiliary: Whether this is auxiliary data (always True)
+        group_id: Group ID (managed automatically by GroupClass)
+        group_name: Group name (managed automatically by GroupClass)
+        parent_techniques: List of parent technique IDs
+        devices: List of devices used
+        settings: List of measurement settings
+        additional_notes: Additional notes
+    """
+    
+    def __init__(self, id: int = 0, type: str = "", start: Optional[datetime] = None,
+                 end: Optional[datetime] = None,
+                 parent_techniques: Optional[List[int]] = None):
+        self.id = id
+        self.type = type
+        self.start = start if start is not None else datetime.now()
+        self.end = end
+        self.auxiliary = True
+        self.group_id: Optional[int] = None
+        self.group_name: Optional[str] = None
+        self.parent_techniques = parent_techniques or []
+        self.devices: List[Device] = []
+        self.settings: List[Parameter] = []
+        self.additional_notes: List[AdditionalNote] = []
+    
+    def add_parent_technique(self, technique_id: int) -> None:
+        """Add a parent technique ID for synchronization."""
+        if technique_id not in self.parent_techniques:
+            self.parent_techniques.append(technique_id)
+    
+    def add_device(self, name: str, type: str, manufacturer: str, model: str,
+                  software_name: Optional[str] = None, software_version: Optional[str] = None) -> Device:
+        """Add a device used in auxiliary measurement."""
+        software = None
+        if software_name and software_version:
+            software = SoftwareObject(name=software_name, version=software_version)
+        
+        device = Device(
+            name=name, type=type, manufacturer=manufacturer, model=model,
+            software=software
+        )
+        self.devices.append(device)
+        return device
+    
+    def add_setting(self, name: str, value: Union[str, int, float, List[Any]], 
+                   unit: Optional[str] = None) -> Parameter:
+        """Add a measurement setting."""
+        setting = Parameter(name=name, value=value, unit=unit)
+        self.settings.append(setting)
+        return setting
+    
+    def add_note(self, name: str, value: str) -> AdditionalNote:
+        """Add an additional note."""
+        note = AdditionalNote(name=name, value=value)
+        self.additional_notes.append(note)
+        return note
+    
+
+    
+    def add_parent_technique(self, technique_id: int) -> None:
+        """Add a parent technique ID for synchronization."""
+        if technique_id not in self.parent_techniques:
+            self.parent_techniques.append(technique_id)
+    
+    def add_device(self, name: str, type: str, manufacturer: str, model: str,
+                  software_name: Optional[str] = None, software_version: Optional[str] = None) -> Device:
+        """Add a device used in this auxiliary measurement."""
+        software = None
+        if software_name and software_version:
+            software = SoftwareObject(name=software_name, version=software_version)
+        
+        device = Device(
+            name=name, type=type, manufacturer=manufacturer, model=model,
+            software=software
+        )
+        self.devices.append(device)
+        return device
+    
+    def add_setting(self, name: str, value: Union[str, int, float, List[Any]], 
+                   unit: Optional[str] = None) -> Parameter:
+        """Add a measurement setting."""
+        setting = Parameter(name=name, value=value, unit=unit)
+        self.settings.append(setting)
+        return setting
+    
+    def add_note(self, name: str, value: str) -> AdditionalNote:
+        """Add an additional note."""
+        note = AdditionalNote(name=name, value=value)
+        self.additional_notes.append(note)
+        return note
+    
+    def find_device(self, name: str) -> Optional[Device]:
+        """Find a device by name."""
+        for device in self.devices:
+            if device.name == name:
+                return device
+        return None
+    
+    def find_setting(self, name: str) -> Optional[Parameter]:
+        """Find a setting by name."""
+        for setting in self.settings:
+            if setting.name == name:
+                return setting
+        return None
+    
+    def find_note(self, name: str) -> Optional[AdditionalNote]:
+        """Find a note by name."""
+        for note in self.additional_notes:
+            if note.name == name:
+                return note
+        return None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation."""
+        primary = {
+            "id": self.id,
+            "auxiliary": self.auxiliary,
+            "type": self.type,
+            "start": self.start.isoformat(),
+        }
+        
+        if self.group_id is not None:
+            primary["group_id"] = self.group_id
+        if self.group_name is not None:
+            primary["group_name"] = self.group_name
+        if self.end:
+            primary["end"] = self.end.isoformat()
+        if self.parent_techniques:
+            primary["parent_techniques"] = self.parent_techniques
+        
+        secondary = {}
+        if self.devices:
+            secondary["devices"] = [device.to_dict() for device in self.devices]
+        if self.settings:
+            secondary["settings"] = [setting.to_dict() for setting in self.settings]
+        
+        result = {"primary": primary}
+        
+        if secondary:
+            result["secondary"] = secondary
+        
+        if self.additional_notes:
+            result["tertiary"] = {
+                "additional_notes": [note.to_dict() for note in self.additional_notes]
+            }
+        
+        return result
+    
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+    
+    def to_netcdf_attrs(self) -> Dict[str, Any]:
+        """Convert to netCDF-compatible attributes."""
+        return {
+            "auxiliary_id": self.id,
+            "auxiliary_type": self.type,
+            "auxiliary_start": self.start.isoformat(),
+            "auxiliary_metadata_json": json.dumps(self.to_dict())
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AuxiliaryMetadata:
+        """Create AuxiliaryMetadata from dictionary representation."""
+        primary = data.get("primary", {})
+        secondary = data.get("secondary", {})
+        tertiary = data.get("tertiary", {})
+        
+        auxiliary = cls(
+            id=primary.get("id", 0),
+            type=primary.get("type", ""),
+            start=datetime.fromisoformat(primary["start"]) if "start" in primary else datetime.now(),
+            end=datetime.fromisoformat(primary["end"]) if "end" in primary else None,
+            parent_techniques=primary.get("parent_techniques", [])
+        )
+        
+        # Reconstruct devices
+        for device_data in secondary.get("devices", []):
+            auxiliary.devices.append(Device.from_dict(device_data))
+        
+        # Reconstruct settings
+        for setting_data in secondary.get("settings", []):
+            auxiliary.settings.append(Parameter.from_dict(setting_data))
+        
+        # Reconstruct additional notes
+        for note_data in tertiary.get("additional_notes", []):
+            auxiliary.additional_notes.append(AdditionalNote.from_dict(note_data))
+        
+        return auxiliary
+    
+    @classmethod
+    def from_json(cls, json_str: str) -> AuxiliaryMetadata:
+        """Create AuxiliaryMetadata from JSON string."""
+        data = json.loads(json_str)
+        return cls.from_dict(data)
+    
+    @classmethod
+    def from_netcdf_attrs(cls, attrs: Dict[str, Any]) -> AuxiliaryMetadata:
+        """Create from netCDF attributes."""
+        if "auxiliary_metadata_json" in attrs:
+            data = json.loads(attrs["auxiliary_metadata_json"])
+            primary = data["primary"]
+            
+            auxiliary = cls(
+                id=primary["id"],
+                type=primary["type"],
+                start=datetime.fromisoformat(primary["start"]),
+                end=datetime.fromisoformat(primary["end"]) if "end" in primary else None,
+                parent_techniques=primary.get("parent_techniques", [])
+            )
+            
+            # Reconstruct devices and settings
+            secondary = data.get("secondary", {})
+            for device_data in secondary.get("devices", []):
+                auxiliary.devices.append(Device.from_dict(device_data))
+            
+            for setting_data in secondary.get("settings", []):
+                auxiliary.settings.append(Parameter.from_dict(setting_data))
+            
+            # Reconstruct additional notes
+            tertiary = data.get("tertiary", {})
+            for note_data in tertiary.get("additional_notes", []):
+                auxiliary.additional_notes.append(AdditionalNote.from_dict(note_data))
+            
+            return auxiliary
+        else:
+            # Fallback to individual attributes
+            return cls(
+                id=attrs.get("auxiliary_id", 0),
+                type=attrs.get("auxiliary_type", ""),
+                start=datetime.fromisoformat(attrs["auxiliary_start"]) if "auxiliary_start" in attrs else datetime.now()
+            )
+
+
+# =============================================================================
+# GROUP METADATA CLASS
+# =============================================================================
+
+class GroupMetadata:
+    """Metadata for technique/auxiliary groups.
+    
+    Groups are organizational units that contain related techniques and/or 
+    auxiliary measurements. They have their own metadata including:
+    - Basic identification (id, name, description)
+    - Purpose and objectives
+    - Custom notes and annotations
+    
+    Example:
+        ```python
+        group = GroupMetadata(id=1, name="CV_Analysis")
+        group.description = "Cyclic voltammetry experiments at different scan rates"
+        group.purpose = "Rate capability analysis"
+        group.add_note("temperature", "25°C")
+        ```
+    """
+    
+    def __init__(self, id: int, name: str, description: str = ""):
+        """Initialize group metadata.
+        
+        Args:
+            id: Unique group ID within the cell
+            name: Group name (e.g., "CV_Analysis", "Characterization")
+            description: Optional description of the group's purpose
+        """
+        # Primary metadata
+        self.id = id
+        self.name = name
+        self.description = description
+        self.purpose = ""
+        self.created_timestamp = datetime.now()
+        
+        # Additional notes
+        self.additional_notes: List[AdditionalNote] = []
+    
+    def add_note(self, name: str, value: Any) -> AdditionalNote:
+        """Add an additional note to this group."""
+        note = AdditionalNote(name=name, value=value)
+        self.additional_notes.append(note)
+        return note
+    
+    def find_note(self, name: str) -> Optional[AdditionalNote]:
+        """Find an additional note by name."""
+        for note in self.additional_notes:
+            if note.name == name:
+                return note
+        return None
+    
+    def remove_note(self, name: str) -> bool:
+        """Remove an additional note by name. Returns True if found and removed."""
+        for i, note in enumerate(self.additional_notes):
+            if note.name == name:
+                del self.additional_notes[i]
+                return True
+        return False
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary following BDG hierarchy."""
+        return {
+            "primary": {
+                "id": self.id,
+                "name": self.name,
+                "description": self.description,
+                "purpose": self.purpose,
+                "created_timestamp": self.created_timestamp.isoformat()
+            },
+            "tertiary": {
+                "additional_notes": [note.to_dict() for note in self.additional_notes]
+            }
+        }
+    
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=2, default=str)
+    
+    def to_netcdf_attrs(self) -> Dict[str, Any]:
+        """Convert to netCDF attributes."""
+        attrs = {
+            "group_metadata_json": self.to_json(),
+            "group_id": self.id,
+            "group_name": self.name,
+            "group_description": self.description,
+            "group_purpose": self.purpose,
+            "group_created": self.created_timestamp.isoformat()
+        }
+        
+        # Add individual note attributes
+        for i, note in enumerate(self.additional_notes):
+            attrs[f"group_note_{i}_name"] = note.name
+            attrs[f"group_note_{i}_value"] = str(note.value)
+        
+        return attrs
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> GroupMetadata:
+        """Create from dictionary."""
+        primary = data["primary"]
+        group = cls(
+            id=primary["id"],
+            name=primary["name"],
+            description=primary.get("description", "")
+        )
+        group.purpose = primary.get("purpose", "")
+        if "created_timestamp" in primary:
+            group.created_timestamp = datetime.fromisoformat(primary["created_timestamp"])
+        
+        # Reconstruct additional notes
+        tertiary = data.get("tertiary", {})
+        for note_data in tertiary.get("additional_notes", []):
+            group.additional_notes.append(AdditionalNote.from_dict(note_data))
+        
+        return group
+    
+    @classmethod
+    def from_netcdf_attrs(cls, attrs: Dict[str, Any]) -> GroupMetadata:
+        """Create from netCDF attributes."""
+        if "group_metadata_json" in attrs:
+            data = json.loads(attrs["group_metadata_json"])
+            return cls.from_dict(data)
+        else:
+            # Fallback to individual attributes
+            group = cls(
+                id=attrs.get("group_id", 0),
+                name=attrs.get("group_name", ""),
+                description=attrs.get("group_description", "")
+            )
+            group.purpose = attrs.get("group_purpose", "")
+            if "group_created" in attrs:
+                group.created_timestamp = datetime.fromisoformat(attrs["group_created"])
+            
+            return group
+


### PR DESCRIPTION
As agreed yesterday, this commit just introduces the small example of how to state measurement errors in all metadata fields, where values with units are stated. We suggest that all value-fields can now hold single values and also tuples:

**Example for single values:**

```diff
[...]

"secondary": { 
    "components": [
      {
        "name": "working_electrode",
        "materials": [
          {
            "id": "SW-001",
            "name": "PFPMAm-co-TEGDMA (1%)",
            "type": "active_material",
            "amount": {
+             "value": 60,
              "unit": "wt.-%"
            }
          },

[...]
```

**Example for tuples stating values and measurement uncertainties:**

```diff
[...]

"secondary": { // in the ideal case this should cover all different cell types
    "components": [
      {
        "name": "working_electrode",
        "materials": [
          {
            "id": "SW-001",
            "name": "PFPMAm-co-TEGDMA (1%)",
            "type": "active_material",
            "amount": { // define amount/number/fraction/...
+             "value": [60.1, 0.5],
              "unit": "wt.-%"
            }
          },

[...]
```